### PR TITLE
Add support for modifiers

### DIFF
--- a/qbraid_qir/qasm3/elements.py
+++ b/qbraid_qir/qasm3/elements.py
@@ -55,6 +55,11 @@ class Context(Enum):
     LOOP = "loop"
 
 
+class InversionOp(Enum):
+    NO_OP = 1
+    INVERT_ROTATION = 2
+
+
 class _ProgramElement(metaclass=ABCMeta):
     @classmethod
     def from_element_list(cls, elements):

--- a/tests/qasm3_qir/converter/test_gates.py
+++ b/tests/qasm3_qir/converter/test_gates.py
@@ -227,12 +227,12 @@ def test_pow_gate_modifier():
     OPENQASM 3;
     include "stdgates.inc";
     qubit q;
-    pow(4) @ h q;
+    inv @ pow(2) @ pow(4) @ h q;
     """
     result = qasm3_to_qir(qasm3_string)
     generated_qir = str(result).splitlines()
     check_attributes(generated_qir, 1, 0)
-    check_single_qubit_gate_op(generated_qir, 4, [0, 0, 0, 0], "h")
+    check_single_qubit_gate_op(generated_qir, 8, [0] * 8, "h")
 
 
 def test_inv_gate_modifier():
@@ -267,7 +267,7 @@ def test_nested_gate_modifiers():
     gate custom p, q {
         pow(1) @ custom2 p, q;
     }
-    pow(2) @ custom q; 
+    inv @ pow(1) @ pow(2) @ custom q; 
     """
     )
     generated_qir = str(complex_qir).splitlines()
@@ -278,19 +278,10 @@ def test_nested_gate_modifiers():
 
 def test_unsupported_modifiers():
     # TO DO : add implementations, but till then we have tests
-    with pytest.raises(Qasm3ConversionError, match="Multiple gate modifiers not supported yet"):
-        _ = qasm3_to_qir(
-            """
-            OPENQASM 3;
-            include "stdgates.inc";
-            qubit q;
-            pow(2) @ pow(2) @ h q;
-            """
-        )
     for modifier in ["ctrl", "negctrl"]:
         with pytest.raises(
             NotImplementedError,
-            match=rf"Modifier GateModifier.{modifier} not supported at the moment",
+            match=r"Controlled modifier gates not yet supported .*",
         ):
             _ = qasm3_to_qir(
                 f"""

--- a/tests/qasm3_qir/converter/test_gates.py
+++ b/tests/qasm3_qir/converter/test_gates.py
@@ -222,7 +222,7 @@ def test_custom_ops(test_name, request):
     check_custom_qasm_gate_op(generated_qir, gate_type)
 
 
-def test_simple_gate_modifier():
+def test_pow_gate_modifier():
     qasm3_string = """
     OPENQASM 3;
     include "stdgates.inc";
@@ -233,6 +233,24 @@ def test_simple_gate_modifier():
     generated_qir = str(result).splitlines()
     check_attributes(generated_qir, 1, 0)
     check_single_qubit_gate_op(generated_qir, 4, [0, 0, 0, 0], "h")
+
+
+def test_inv_gate_modifier():
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+    qubit q;
+    inv @ h q;
+    inv @ y q;
+    inv @ rx(0.5) q;
+    inv @ U(0.5, 0.5, 0.5) q;
+    """
+    result = qasm3_to_qir(qasm3_string)
+    generated_qir = str(result).splitlines()
+    check_attributes(generated_qir, 1, 0)
+    check_single_qubit_gate_op(generated_qir, 1, [0], "h")
+    check_single_qubit_gate_op(generated_qir, 1, [0], "y")
+    check_single_qubit_rotation_op(generated_qir, 1, [0], [-0.5], "rx")
 
 
 def test_nested_gate_modifiers():
@@ -269,7 +287,7 @@ def test_unsupported_modifiers():
             pow(2) @ pow(2) @ h q;
             """
         )
-    for modifier in ["ctrl", "inv", "negctrl"]:
+    for modifier in ["ctrl", "negctrl"]:
         with pytest.raises(
             NotImplementedError,
             match=rf"Modifier GateModifier.{modifier} not supported at the moment",


### PR DESCRIPTION
Fixes #75 

## Changes
- Added initial implementation for modifier support
- Modifier support - 
    - [x] pow
    - [x] inv
    - [x] Nested 
    - [x] Chain
    - [ ] ctrl and negctrl

I didn't find much support for the custom-controlled operations i.e. `ctrl @` in pyqir, so maybe we can go ahead with this for now. 