### PR TITLE
For loop implementation

### DIFF
--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -26,19 +26,24 @@ import pyqir._native
 import pyqir.rt
 from openqasm3.ast import (
     AliasStatement,
+    ArrayLiteral,
     ArrayType,
     BinaryExpression,
+    BitstringLiteral,
     BooleanLiteral,
     BoolType,
     BranchingStatement,
     ClassicalAssignment,
     ClassicalDeclaration,
     ConstantDeclaration,
+    DiscreteSet,
     DurationLiteral,
+    Expression,
     FloatLiteral,
 )
 from openqasm3.ast import FloatType as Qasm3FloatType
 from openqasm3.ast import (
+    ForInLoop,
     GateModifierName,
     Identifier,
     ImaginaryLiteral,
@@ -62,6 +67,7 @@ from openqasm3.ast import (
     Statement,
     SubroutineDefinition,
     UnaryExpression,
+    WhileLoop,
 )
 from pyqir import BasicBlock, Builder, Constant
 from pyqir import IntType as qirIntType
@@ -78,6 +84,7 @@ from .oq3_maps import (
 )
 
 _log = logging.getLogger(name=__name__)
+_log.setLevel(logging.INFO)
 
 
 class ProgramElementVisitor(metaclass=ABCMeta):
@@ -164,6 +171,12 @@ class BasicQasmVisitor(ProgramElementVisitor):
     def _check_in_scope(self, var_name: str) -> bool:
         curr_scope = self._get_scope()
         return var_name in curr_scope
+
+    def _find_in_visible_scope(self, var_name: str) -> Union[Variable, None]:
+        for scope in reversed(self._scope):
+            if var_name in scope:
+                return scope[var_name]
+        return None
 
     def _update_scope(self, variable: Variable) -> None:
         if len(self._scope) == 0:
@@ -297,7 +310,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
                         ]
                     )
                 else:
-                    qid = qubit.indices[0][0].value
+                    qid = self._evaluate_expression(qubit.indices[0][0])
                     self._validate_register_index(qid, qreg_size, qubit=True)
                     qreg_qids = [self._qubit_labels[f"{qreg_name}_{qid}"]]
                     openqasm_qubits.append(qubit)
@@ -944,11 +957,12 @@ class BasicQasmVisitor(ProgramElementVisitor):
         if isinstance(lvalue, IndexedIdentifier):
             var_name = var_name.name
 
-        if not self._check_in_scope(var_name):
+        if self._find_in_visible_scope(var_name) is None:
             self._print_err_location(statement.span)
             raise Qasm3ConversionError(f"Undefined variable {var_name} in assignment")
 
-        if self._get_scope()[var_name].is_constant:
+        var = self._find_in_visible_scope(var_name)
+        if var.is_constant:
             self._print_err_location(statement.span)
             raise Qasm3ConversionError(f"Assignment to constant variable {var_name} not allowed")
 
@@ -956,15 +970,15 @@ class BasicQasmVisitor(ProgramElementVisitor):
 
         # currently we support single array assignment only
         # range based assignment not supported yet
-        self._validate_variable_assignment_value(self._get_scope()[var_name], var_value)
+        self._validate_variable_assignment_value(var, var_value)
 
         # handle assignment for arrays
         if isinstance(lvalue, IndexedIdentifier):
             indices = lvalue.indices
             flat_index = self._analyse_classical_indices(indices, var_name)
-            self._get_scope()[var_name].value[flat_index] = var_value
+            var.value[flat_index] = var_value
         else:
-            self._get_scope()[var_name].value = var_value
+            var.value = var_value
 
     # pylint: disable-next=too-many-return-statements
     def _evaluate_expression(self, expression: Any) -> bool:
@@ -986,7 +1000,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
             raise Qasm3ConversionError(f"Unsupported expression type {type(expression)}")
 
         def _check_var_in_scope(var_name, span):
-            if not self._check_in_scope(var_name):
+            if self._find_in_visible_scope(var_name) is None:
                 self._print_err_location(span)
                 raise Qasm3ConversionError(f"Undefined identifier {var_name} in expression")
 
@@ -998,11 +1012,11 @@ class BasicQasmVisitor(ProgramElementVisitor):
         def _get_var_value(var_name, indices=None):
             var_value = None
             if isinstance(expression, Identifier):
-                var_value = self._get_scope()[var_name].value
+                var_value = self._find_in_visible_scope(var_name).value
             else:
                 # indices is a list of singleton lists
                 flat_index = self._analyse_classical_indices(indices, var_name)
-                var_value = self._get_scope()[var_name].value[flat_index]
+                var_value = self._find_in_visible_scope(var_name).value[flat_index]
             return var_value
 
         def _analyse_index_expression(index_expr):
@@ -1165,6 +1179,55 @@ class BasicQasmVisitor(ProgramElementVisitor):
             one=lambda: _visit_statement_block(if_block),
         )
 
+    def _visit_forin_loop(self, statement: ForInLoop) -> None:
+        def _declare_loop_variable(statement: ForInLoop, init_exp: Expression):
+            self._visit_classical_declaration(
+                ClassicalDeclaration(statement.type, statement.identifier, init_exp)
+            )
+
+        # Compute loop variable values
+        if isinstance(statement.set_declaration, RangeDefinition):
+            init_exp = statement.set_declaration.start
+            startval = self._evaluate_expression(init_exp)
+            range_def = statement.set_declaration
+            stepval = (
+                1 if range_def.step is None else self._evaluate_expression(range_def.step)
+            )  # Can be reused
+            endval = self._evaluate_expression(range_def.end)
+            irange = list(range(startval, endval + stepval, stepval))
+        elif isinstance(statement.set_declaration, (DiscreteSet, ArrayLiteral)):
+            init_exp = statement.set_declaration.values[0]
+            irange = [self._evaluate_expression(exp) for exp in statement.set_declaration.values]
+        elif isinstance(statement.set_declaration, BitstringLiteral):
+            bitstring = statement.set_declaration
+            s = bin(bitstring.value).removeprefix("0b")
+            if len(s) < bitstring.width:
+                s = "0" * (bitstring.width - len(s)) + s
+            init_exp = BooleanLiteral(bool(s[0]))
+            irange = [bool(b) for b in s]
+        else:
+            raise Qasm3ConversionError(
+                f"Unexpected type {type(statement.set_declaration)} of set_declaration in loop."
+            )
+
+        i = None  # will store iteration Variable to update to loop scope
+        for ival in irange:
+            self._push_scope({})  # loop scope
+            if i is None:
+                # Initialize loop variable for first time in loop scope
+                _declare_loop_variable(statement, init_exp)
+            else:
+                # Update scope with current value of loop Variable
+                i.value = ival
+                self._update_scope(i)
+            for stmt in statement.block:
+                self.visit_statement(stmt)
+            i = self._get_scope()[statement.identifier.name]
+            self._pop_scope()  # scope not persistent between loop iterations
+
+    def _visit_while_loop(self, statement: WhileLoop) -> None:
+        pass
+
     def visit_contextual_statement(self, statement: Statement) -> None:
         pass
 
@@ -1202,6 +1265,10 @@ class BasicQasmVisitor(ProgramElementVisitor):
             self._visit_constant_declaration(statement)
         elif isinstance(statement, BranchingStatement):
             self._visit_branching_statement(statement)
+        elif isinstance(statement, ForInLoop):
+            self._visit_forin_loop(statement)
+        elif isinstance(statement, WhileLoop):
+            self._visit_while_loop(statement)
         elif isinstance(statement, SubroutineDefinition):
             raise NotImplementedError("OpenQASM 3 subroutines not yet supported")
         elif isinstance(statement, AliasStatement):

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -28,7 +28,6 @@ from openqasm3.ast import (
     AliasStatement,
     ArrayType,
     BinaryExpression,
-    BitstringLiteral,
     BooleanLiteral,
     BoolType,
     BranchingStatement,

--- a/tests/qasm3_qir/converter/test_loop.py
+++ b/tests/qasm3_qir/converter/test_loop.py
@@ -1,0 +1,268 @@
+# Copyright (C) 2023 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Module containing unit tests for parsing, unrolling, and
+converting OpenQASM3 programs that contain loops.
+
+"""
+
+from qbraid_qir.qasm3 import qasm3_to_qir
+
+EXAMPLE_WITHOUT_LOOP = """
+OPENQASM 3.0;
+include "stdgates.inc";
+
+qubit[4] q;
+bit[4] c;
+
+h q;
+
+cx q[0], q[1];
+cx q[1], q[2];
+cx q[2], q[3];
+
+measure q->c;
+"""
+
+
+EXAMPLE_QIR_OUTPUT = """; ModuleID = 'test'
+source_filename = "test"
+
+%Qubit = type opaque
+%Result = type opaque
+
+define void @main() #0 {
+entry:
+  call void @__quantum__rt__initialize(i8* null)
+  call void @__quantum__qis__h__body(%Qubit* null)
+  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 1 to %Qubit*))
+  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 2 to %Qubit*))
+  call void @__quantum__qis__h__body(%Qubit* inttoptr (i64 3 to %Qubit*))
+  call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))
+  call void @__quantum__qis__cnot__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Qubit* inttoptr (i64 2 to %Qubit*))
+  call void @__quantum__qis__cnot__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Qubit* inttoptr (i64 3 to %Qubit*))
+  call void @__quantum__qis__mz__body(%Qubit* null, %Result* null)
+  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 1 to %Qubit*), %Result* inttoptr (i64 1 to %Result*))
+  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 2 to %Qubit*), %Result* inttoptr (i64 2 to %Result*))
+  call void @__quantum__qis__mz__body(%Qubit* inttoptr (i64 3 to %Qubit*), %Result* inttoptr (i64 3 to %Result*))
+  call void @__quantum__rt__result_record_output(%Result* null, i8* null)
+  call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
+  call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 2 to %Result*), i8* null)
+  call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 3 to %Result*), i8* null)
+  ret void
+}
+
+declare void @__quantum__rt__initialize(i8*)
+
+declare void @__quantum__qis__h__body(%Qubit*)
+
+declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*)
+
+declare void @__quantum__qis__mz__body(%Qubit*, %Result* writeonly) #1
+
+declare void @__quantum__rt__result_record_output(%Result*, i8*)
+
+attributes #0 = { "entry_point" "output_labeling_schema" "qir_profiles"="custom" "required_num_qubits"="4" "required_num_results"="4" }
+attributes #1 = { "irreversible" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+
+!0 = !{i32 1, !"qir_major_version", i32 1}
+!1 = !{i32 7, !"qir_minor_version", i32 0}
+!2 = !{i32 1, !"dynamic_qubit_management", i1 false}
+!3 = !{i32 1, !"dynamic_result_management", i1 false}
+"""
+
+
+def test_convert_qasm3_for_loop():
+    """Test converting a QASM3 program that contains a for loop."""
+    qir_expected = qasm3_to_qir(EXAMPLE_WITHOUT_LOOP, name="test")
+    qir_from_loop = qasm3_to_qir(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[4] q;
+        bit[4] c;
+
+        h q;
+        for int i in [0:2]{ 
+            cx q[i], q[i+1];
+        } 
+        measure q->c;
+        """,
+        name="test",
+    )
+    assert str(qir_expected) == str(qir_from_loop)
+    assert str(qir_from_loop) == EXAMPLE_QIR_OUTPUT
+
+
+def test_convert_qasm3_for_loop_shadow():
+    """Test for loop where loop variable shadows variable from global scope."""
+    qir_expected = qasm3_to_qir(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[4] q;
+        bit[4] c;
+
+        int i = 3;
+
+        h q;
+        cx q[0], q[1];
+        cx q[1], q[2];
+        cx q[2], q[3];
+        h q[i];
+        measure q->c;
+        """,
+        name="test",
+    )
+    qir_from_loop = qasm3_to_qir(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[4] q;
+        bit[4] c;
+
+        int i = 3;
+
+        h q;
+        for int i in [0:2]{
+            cx q[i], q[i+1];
+        }
+        h q[i];
+        measure q->c;
+        """,
+        name="test",
+    )
+    assert str(qir_expected) == str(qir_from_loop)
+
+
+def test_convert_qasm3_for_loop_enclosing():
+    """Test for loop where variable from outer loop is accessed from inside the loop."""
+    qir_expected = qasm3_to_qir(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[4] q;
+        bit[4] c;
+
+        int j = 3;
+
+        h q;
+        cx q[0], q[1];
+        h q[j];
+        cx q[1], q[2];
+        h q[j];
+        cx q[2], q[3];
+        h q[j];
+        measure q->c;
+        """,
+        name="test",
+    )
+    qir_from_loop = qasm3_to_qir(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[4] q;
+        bit[4] c;
+
+        int j = 3;
+
+        h q;
+        for int i in [0:2]{
+            cx q[i], q[i+1];
+            h q[j];
+        }
+        measure q->c;
+        """,
+        name="test",
+    )
+    assert str(qir_expected) == str(qir_from_loop)
+
+
+def test_convert_qasm3_for_loop_enclosing_modifying():
+    """Test for loop where variable from outer loop is modified from inside the loop."""
+    qir_expected = qasm3_to_qir(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[4] q;
+        bit[4] c;
+
+        int j = 0;
+
+        h q;
+        cx q[0], q[1];
+        h q[j];
+        j += 1;
+        cx q[1], q[2];
+        h q[j];
+        j += 1;
+        cx q[2], q[3];
+        h q[j];
+        j += 1;
+
+        h q[j];
+        measure q->c;
+        """,
+        name="test",
+    )
+    qir_from_loop = qasm3_to_qir(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[4] q;
+        bit[4] c;
+
+        int j = 0;
+
+        h q;
+        for int i in [0:2]{
+            cx q[i], q[i+1];
+            h q[j];
+            j += 1;
+        }
+        h q[j];
+        measure q->c;
+        """,
+        name="test",
+    )
+    assert str(qir_expected) == str(qir_from_loop)
+
+
+def test_convert_qasm3_for_loop_discrete_set():
+    """Test converting a QASM3 program that contains a for loop initialized from a DiscreteSet."""
+    qir_expected = qasm3_to_qir(EXAMPLE_WITHOUT_LOOP, name="test")
+    qir_from_loop = qasm3_to_qir(
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        qubit[4] q;
+        bit[4] c;
+
+        h q;
+        for int i in {0, 1, 2} { 
+            cx q[i], q[i+1];
+        } 
+        measure q->c;
+        """,
+        name="test",
+    )
+    assert str(qir_expected) == str(qir_from_loop)
+    assert str(qir_from_loop) == EXAMPLE_QIR_OUTPUT


### PR DESCRIPTION
Addressing #67, implements conversion of for loops to QIR for two supported types of the set declaration (`RangeDefinition`, `DiscreteSet`). Scoping is updated so that variables from enclosing scopes are visible inside the loop block, but do not cause errors due to redeclaration of identifiers when these variables are shadowed inside the block.

Tests are included for the functionality described above in new module at `qbraid-qir/tests/qasm3_qir/converter/test_loop.py`.
