### PR TITLE
`switch` implementation for `qasm3-qir`

### DIFF
--- a/qbraid_qir/qasm3/elements.py
+++ b/qbraid_qir/qasm3/elements.py
@@ -70,8 +70,8 @@ class Variable:
         name: str,
         base_type,
         base_size: int,
-        dims: list[int],
-        value: Optional[Union[int, float, list]],
+        dims: list[int] = None,
+        value: Optional[Union[int, float, list]] = None,
         is_constant: bool = False,
     ):
         self.name = name

--- a/qbraid_qir/qasm3/oq3_maps.py
+++ b/qbraid_qir/qasm3/oq3_maps.py
@@ -23,9 +23,13 @@ from openqasm3.ast import (
     ArrayType,
     BitType,
     BoolType,
+    ClassicalDeclaration,
     ComplexType,
     FloatType,
     IntType,
+    QuantumGateDefinition,
+    QubitDeclaration,
+    SubroutineDefinition,
     UintType,
 )
 
@@ -670,3 +674,12 @@ VARIABLE_TYPE_CAST_MAP = {
 
 # Reference : https://openqasm.com/language/types.html#arrays
 MAX_ARRAY_DIMENSIONS = 7
+
+# Reference : https://openqasm.com/language/classical.html#the-switch-statement
+# Paragraph 14
+SWITCH_BLACKLIST_STMTS = {
+    QubitDeclaration,
+    ClassicalDeclaration,
+    SubroutineDefinition,
+    QuantumGateDefinition,
+}

--- a/qbraid_qir/qasm3/oq3_maps.py
+++ b/qbraid_qir/qasm3/oq3_maps.py
@@ -20,7 +20,6 @@ import numpy as np
 import pyqir
 from openqasm3.ast import (
     AngleType,
-    ArrayType,
     BitType,
     BoolType,
     ClassicalDeclaration,
@@ -656,9 +655,8 @@ VARIABLE_TYPE_MAP = {
     UintType: int,
     BoolType: bool,
     FloatType: float,
-    ArrayType: None,  # not sure
-    AngleType: None,  # not sure
     ComplexType: complex,
+    # AngleType: None,  # not sure
 }
 
 # Reference: https://openqasm.com/language/types.html#allowed-casts

--- a/tests/qasm3_qir/converter/declarations/test_classical.py
+++ b/tests/qasm3_qir/converter/declarations/test_classical.py
@@ -209,17 +209,26 @@ def test_array_assignments():
     bool f = true;
 
     arr_int[0][1] = a*a;
+    arr_int[0,1] = a*a;
+
     arr_uint[0][1] = b*b;
+    arr_uint[0,1] = b*b;
+
     arr_float32[0][1] = c*c;
+    arr_float32[0,1] = c*c;
+    
     arr_float64[0][1] = d*d;
+    arr_float64[0,1] = d*d;
+
     arr_bool[0][1] = f;
+    arr_bool[0,1] = f;
 
     qubit q;
-    rx(arr_int[0][1]) q;
+    rx(arr_int[0,1]) q;
     rx(arr_uint[0][1]) q;
-    rx(arr_float32[0][1]) q;
+    rx(arr_float32[0,1]) q;
     rx(arr_float64[0][1]) q;
-    rx(arr_bool[0][1]) q;
+    rx(arr_bool[0,1]) q;
     """
 
     a = 2

--- a/tests/qasm3_qir/converter/test_switch.py
+++ b/tests/qasm3_qir/converter/test_switch.py
@@ -1,0 +1,160 @@
+# Copyright (C) 2024 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Module containing unit tests for converting OpenQASM 3 programs
+with alias statements to QIR.
+
+"""
+
+import re
+
+import pytest
+
+from qbraid_qir.qasm3 import qasm3_to_qir
+from qbraid_qir.qasm3.exceptions import Qasm3ConversionError
+from tests.qir_utils import check_attributes, check_single_qubit_gate_op
+
+
+def test_switch():
+    """Test converting OpenQASM 3 program with openqasm3.ast.SwitchStatement."""
+
+    qasm3_switch_program = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    
+    const int i = 5;
+    qubit q;
+
+    switch(i) {
+    case 1,3,5,7 {
+        x q;
+    }
+    case 2,4,6,8 {
+        y q;
+    }
+    default {
+        z q;
+    }
+    }
+    """
+
+    result = qasm3_to_qir(qasm3_switch_program, name="test")
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 1)
+    check_single_qubit_gate_op(generated_qir, 1, [0], "x")
+
+
+def test_switch_default():
+    """Test converting OpenQASM 3 program with openqasm3.ast.SwitchStatement and default case."""
+
+    qasm3_switch_program = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    
+    const int i = 10;
+    qubit q;
+
+    switch(i) {
+    case 1,3,5,7 {
+        x q;
+    }
+    case 2,4,6,8 {
+        y q;
+    }
+    default {
+        z q;
+    }
+    }
+    """
+
+    result = qasm3_to_qir(qasm3_switch_program, name="test")
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 1)
+    check_single_qubit_gate_op(generated_qir, 1, [0], "z")
+
+
+def test_switch_identifier_case():
+    """Test converting OpenQASM 3 program with openqasm3.ast.SwitchStatement and identifier case."""
+
+    qasm3_switch_program = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    
+    const int i = 4;
+    const int j = 4;
+    qubit q;
+
+    switch(i) {
+    case 6, j {
+        x q;
+    }
+    default {
+        z q;
+    }
+    }
+    """
+
+    result = qasm3_to_qir(qasm3_switch_program, name="test")
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 1)
+    check_single_qubit_gate_op(generated_qir, 1, [0], "x")
+
+
+def test_switch_duplicate_cases():
+    """Test that switch raises error if duplicate values are present in case."""
+
+    with pytest.raises(
+        Qasm3ConversionError, match=re.escape("Duplicate case value 4 in switch statement")
+    ):
+        qasm3_switch_program = """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        
+        const int i = 4;
+        qubit q;
+
+        switch(i) {
+        case 4, 4 {
+            x q;
+        }
+        default {
+            z q;
+        }
+        }
+        """
+
+        qasm3_to_qir(qasm3_switch_program, name="test")
+
+
+def test_no_case_switch():
+    """Test that switch raises error if no case is present."""
+
+    with pytest.raises(
+        Qasm3ConversionError, match=re.escape("Switch statement must have at least one case")
+    ):
+        qasm3_switch_program = """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        
+        const int i = 4;
+        qubit q;
+
+        switch(i) {
+        default {
+            z q;
+        }
+        }
+        """
+
+        qasm3_to_qir(qasm3_switch_program, name="test")

--- a/tests/qasm3_qir/converter/test_switch.py
+++ b/tests/qasm3_qir/converter/test_switch.py
@@ -264,3 +264,36 @@ def test_invalid_array_switch_target(invalid_type):
     ):
         qasm3_switch_program = base_invalid_program
         qasm3_to_qir(qasm3_switch_program, name="test")
+
+
+@pytest.mark.parametrize(
+    "invalid_stmt",
+    ["def test1() { int i = 1; }", "array[int[32], 3, 2] arr_int;", "gate test_1() q { h q;}"],
+)
+def test_unsupported_statements_in_case(invalid_stmt):
+    """Test that switch raises error if invalid statements are present in the case block"""
+
+    base_invalid_program = (
+        """
+
+    OPENQASM 3.0;
+    include "stdgates.inc"; 
+    qubit q;
+    int i = 4;
+
+    switch(i) {
+        case 4 {
+            x q;
+    """
+        + invalid_stmt
+        + """
+        }
+        default {
+            z q;
+        }
+    }
+    """
+    )
+    with pytest.raises(Qasm3ConversionError, match=r"Unsupported statement .*"):
+        qasm3_switch_program = base_invalid_program
+        qasm3_to_qir(qasm3_switch_program, name="test")

--- a/tests/qasm3_qir/converter/test_switch.py
+++ b/tests/qasm3_qir/converter/test_switch.py
@@ -354,6 +354,34 @@ def test_non_int_expression_case():
         qasm3_to_qir(qasm3_switch_program, name="test")
 
 
+def test_non_int_variable_expression():
+    """Test that switch raises error if case expression has a non-int
+    variable in expression."""
+
+    base_invalid_program = """
+    OPENQASM 3.0;
+    include "stdgates.inc";
+    const int i = 4;
+    const float f = 4.0;
+    qubit q;
+
+    switch(i) {
+        case f, 2 {
+            x q;
+        }
+        default {
+            z q;
+        }
+    }
+    """
+    with pytest.raises(
+        Qasm3ConversionError,
+        match=r"Invalid type of variable .* for required type <class 'openqasm3.ast.IntType'>",
+    ):
+        qasm3_switch_program = base_invalid_program
+        qasm3_to_qir(qasm3_switch_program, name="test")
+
+
 def test_non_constant_expression_case():
     """Test that switch raises error if case expression is not a constant."""
 

--- a/tests/qasm3_qir/fixtures/gates.py
+++ b/tests/qasm3_qir/fixtures/gates.py
@@ -338,4 +338,24 @@ CUSTOM_GATE_INCORRECT_TESTS = {
         """,
         "Recursive definitions not allowed .*",
     ),
+    "duplicate_definition": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        gate custom_gate(a,b) p, q{
+            rx(a) p;
+            ry(b) q;
+        }
+
+        gate custom_gate(a,b) p, q{
+            rx(a) p;
+            ry(b) q;
+        }
+
+        qubit[2] q1;
+        custom_gate(0.5, 0.5) q1;  // duplicate definition
+        """,
+        "Duplicate gate definition for custom_gate",
+    ),
 }

--- a/tests/qasm3_qir/fixtures/variables.py
+++ b/tests/qasm3_qir/fixtures/variables.py
@@ -92,6 +92,15 @@ DECLARATION_TESTS = {
         """,
         "Invalid base size 23 for float variable x",
     ),
+    "unsupported_types": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+
+        angle x = 3.4;
+        """,
+        "Invalid type <class 'openqasm3.ast.AngleType'> for variable x",
+    ),
     "imaginary_variable": (
         """
         OPENQASM 3.0;
@@ -174,6 +183,15 @@ ASSIGNMENT_TESTS = {
             "Invalid assignment of type <class 'float'> to variable x of type "
             "<class 'openqasm3.ast.BitType'>"
         ),
+    ),
+    "invalid_assignment_for_range": (
+        """
+        OPENQASM 3.0;
+        include "stdgates.inc";
+        array[int[32], 4, 4] my_arr;
+        my_arr[0, 1:1] = 3;
+        """,
+        "Range based indexing .* not supported for classical variable .*",
     ),
     "int_out_of_range": (
         """


### PR DESCRIPTION
Fixes #80 

# Changes
- Added handler for `switch` case in openqasm according to the official reference.
- Also made some tweaks to the handling of array indexing
- Still a WIP , following tasks are left - 
   - [x] Handle type checking for target 
   - [x] Check for unsupported statements
   - [x] Ensure expressions are const int expressions 
   - [x] Add more unit tests