### PR TITLE
Fix `for` with subroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Types of changes:
 * Update `CONTRIBUTING.md` to mention changelog updates ( [#140](https://github.com/qBraid/qbraid-qir/pull/140) )
 
 ### 🐛  Bug Fixes
+* Fix function block issues where qubit references were not getting populated correctly. Users can now use `for`, `switch` and other constructs inside functions. ( [#141](https://github.com/qBraid/qbraid-qir/pull/141) )
 
 ### ⬇️  Dependency Updates 
 

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -121,8 +121,10 @@ class BasicQasmVisitor(ProgramElementVisitor):
         self._context = deque([Context.GLOBAL])
         self._qubit_labels = {}
         self._clbit_labels = {}
-        self._qreg_size_map = {}
-        self._creg_size_map = {}
+        self._global_qreg_size_map = {}
+        self._function_qreg_size_map = deque([])  # for nested functions
+        self._function_qreg_transform_map = deque([])  # for nested functions
+        self._global_creg_size_map = {}
         self._custom_gates = {}
         self._subroutine_defns = {}
         self._measured_qubits = {}
@@ -376,7 +378,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
             register_size = 1 if register.type.size is None else register.type.size.value
         register_name = register.qubit.name if is_qubit else register.identifier.name
 
-        size_map = self._qreg_size_map if is_qubit else self._creg_size_map
+        size_map = self._global_qreg_size_map if is_qubit else self._global_creg_size_map
         label_map = self._qubit_labels if is_qubit else self._clbit_labels
 
         if self._check_in_scope(register_name, self._get_curr_scope()):
@@ -578,7 +580,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
         source = statement.measure.qubit
         target = statement.target
         source_id, target_id = None, None
-
+        # TODO: handle in-function measurements
         source_name = source.name
         if isinstance(source, IndexedIdentifier):
             source_name = source.name.name
@@ -599,13 +601,13 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 )
             target_id = target.indices[0][0].value
 
-        if source_name not in self._qreg_size_map:
+        if source_name not in self._global_qreg_size_map:
             self._print_err_location(statement.span)
             raise Qasm3ConversionError(
                 f"Missing register declaration for {source_name} in measurement "
                 f"operation {statement}"
             )
-        if target_name not in self._creg_size_map:
+        if target_name not in self._global_creg_size_map:
             self._print_err_location(statement.span)
             raise Qasm3ConversionError(
                 f"Missing register declaration for {target_name} in measurement "
@@ -631,17 +633,21 @@ class BasicQasmVisitor(ProgramElementVisitor):
             pyqir._native.mz(self._builder, source_qubit, result)
 
         if source_id is None and target_id is None:
-            if self._qreg_size_map[source_name] != self._creg_size_map[target_name]:
+            if self._global_qreg_size_map[source_name] != self._global_creg_size_map[target_name]:
                 self._print_err_location(statement.span)
                 raise Qasm3ConversionError(
                     f"Register sizes of {source_name} and {target_name} do not match "
                     "for measurement operation"
                 )
-            for i in range(self._qreg_size_map[source_name]):
+            for i in range(self._global_qreg_size_map[source_name]):
                 _build_qir_measurement(source_name, i, target_name, i)
         else:
-            self._validate_register_index(source_id, self._qreg_size_map[source_name], qubit=True)
-            self._validate_register_index(target_id, self._creg_size_map[target_name], qubit=False)
+            self._validate_register_index(
+                source_id, self._global_qreg_size_map[source_name], qubit=True
+            )
+            self._validate_register_index(
+                target_id, self._global_creg_size_map[target_name], qubit=False
+            )
             _build_qir_measurement(source_name, source_id, target_name, target_id)
 
     def _visit_reset(self, statement: QuantumReset) -> None:
@@ -654,7 +660,13 @@ class BasicQasmVisitor(ProgramElementVisitor):
             None
         """
         _log.debug("Visiting reset statement '%s'", str(statement))
-        qubit_ids = self._get_op_qubits(statement, self._qreg_size_map, True)
+        if len(self._function_qreg_size_map) > 0:  # atleast in SOME function scope
+            # transform qubits to use the global qreg identifiers
+            statement.qubits = self._transform_function_qubits(
+                statement, self._function_qreg_size_map[-1], self._function_qreg_transform_map[-1]
+            )
+        qubit_ids = self._get_op_qubits(statement, self._global_qreg_size_map, True)
+
         for qid in qubit_ids:
             pyqir._native.reset(self._builder, qid)
 
@@ -668,8 +680,14 @@ class BasicQasmVisitor(ProgramElementVisitor):
             None
         """
         # if barrier is applied to ALL qubits at once, we are fine
-        barrier_qubits = self._get_op_qubits(barrier, self._qreg_size_map)
-        total_qubit_count = sum(self._qreg_size_map.values())
+        if len(self._function_qreg_size_map) > 0:  # atleast in SOME function scope
+            # transform qubits to use the global qreg identifiers
+            barrier.qubits = self._transform_function_qubits(
+                barrier, self._function_qreg_size_map[-1], self._function_qreg_transform_map[-1]
+            )
+
+        barrier_qubits = self._get_op_qubits(barrier, self._global_qreg_size_map)
+        total_qubit_count = sum(self._global_qreg_size_map.values())
         if len(barrier_qubits) == total_qubit_count:
             pyqir._native.barrier(self._builder)
         else:
@@ -738,7 +756,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
 
         _log.debug("Visiting basic gate operation '%s'", str(operation))
         op_name: str = operation.name.name
-        op_qubits = self._get_op_qubits(operation, self._qreg_size_map)
+        op_qubits = self._get_op_qubits(operation, self._global_qreg_size_map)
         inverse_action = None
         if not inverse:
             qir_func, op_qubit_count = map_qasm_op_to_pyqir_callable(op_name)
@@ -849,7 +867,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
         _log.debug("Visiting custom gate operation '%s'", str(operation))
         gate_name: str = operation.name.name
         gate_definition: QuantumGateDefinition = self._custom_gates[gate_name]
-        op_qubits = self._get_op_qubits(operation, self._qreg_size_map, qir_form=False)
+        op_qubits = self._get_op_qubits(operation, self._global_qreg_size_map, qir_form=False)
 
         self._validate_gate_call(operation, gate_definition, len(op_qubits))
         # we need this because the gates applied inside a gate definition use the
@@ -869,6 +887,8 @@ class BasicQasmVisitor(ProgramElementVisitor):
         gate_definition_ops = copy.deepcopy(gate_definition.body)
         if inverse:
             gate_definition_ops.reverse()
+
+        self._push_context(Context.GATE)
 
         for gate_op in gate_definition_ops:
             if gate_op.name.name == gate_name:
@@ -892,6 +912,8 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 # TODO: add control flow support
                 self._print_err_location(gate_op.span)
                 raise Qasm3ConversionError(f"Unsupported gate definition statement {gate_op}")
+
+        self._restore_context()
 
     def _collapse_gate_modifiers(self, operation: QuantumGate) -> tuple:
         """Collapse the gate modifiers of a gate operation.
@@ -936,8 +958,17 @@ class BasicQasmVisitor(ProgramElementVisitor):
             None
         """
         power_value, inverse_value = self._collapse_gate_modifiers(operation)
+        operation = copy.deepcopy(operation)
+
+        # only needs to be done once for a gate operation
+        if not self._in_gate_scope() and len(self._function_qreg_size_map) > 0:
+            # atleast in SOME function scope
+            # transform qubits to use the global qreg identifiers
+            operation.qubits = self._transform_function_qubits(
+                operation, self._function_qreg_size_map[-1], self._function_qreg_transform_map[-1]
+            )
         # Applying the inverse first and then the power is same as
-        # apply the power first and then inverting the
+        # apply the power first and then inverting the result
         for _ in range(power_value):
             if operation.name.name in self._custom_gates:
                 self._visit_custom_gate_operation(operation, inverse_value)
@@ -1553,11 +1584,11 @@ class BasicQasmVisitor(ProgramElementVisitor):
 
         reg_id, reg_name = self._get_branch_params(condition)
 
-        if reg_name not in self._creg_size_map:
+        if reg_name not in self._global_creg_size_map:
             raise Qasm3ConversionError(
                 f"Missing register declaration for {reg_name} in {condition}"
             )
-        self._validate_register_index(reg_id, self._creg_size_map[reg_name], qubit=False)
+        self._validate_register_index(reg_id, self._global_creg_size_map[reg_name], qubit=False)
 
         def _visit_statement_block(block):
             for stmt in block:
@@ -1597,7 +1628,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
 
         for ival in irange:
             self._push_context(Context.BLOCK)
-            self._push_scope({})  # loop scope
+            self._push_scope({})
 
             # Initialize loop variable in loop scope
             # need to re-declare as we discard the block scope in subsequent
@@ -1614,7 +1645,8 @@ class BasicQasmVisitor(ProgramElementVisitor):
             for stmt in statement.block:
                 self.visit_statement(stmt)
 
-            self._pop_scope()  # scope not persistent between loop iterations
+            # scope not persistent between loop iterations
+            self._pop_scope()
             self._restore_context()
 
     def _visit_subroutine_definition(self, statement: SubroutineDefinition) -> None:
@@ -1694,19 +1726,19 @@ class BasicQasmVisitor(ProgramElementVisitor):
             )
 
     def _transform_function_qubits(
-        self, gate_op: QuantumGate, formal_qreg_sizes: dict[str:int], qubit_map: dict[tuple:tuple]
+        self, q_op, formal_qreg_sizes: dict[str:int], qubit_map: dict[tuple:tuple]
     ) -> list:
         """Transform the qubits of a function call to the actual qubits.
 
         Args:
-            gate_op (QuantumGate): The gate operation to transform.
+            gate_op : The quantum operation to transform.
             formal_qreg_sizes (dict[str: int]): The formal qubit register sizes.
             qubit_map (dict[tuple: tuple]): The mapping of formal qubits to actual qubits.
 
         Returns:
             None
         """
-        expanded_op_qubits = self._get_op_qubits(gate_op, formal_qreg_sizes, qir_form=False)
+        expanded_op_qubits = self._get_op_qubits(q_op, formal_qreg_sizes, qir_form=False)
 
         transformed_qubits = []
         for qubit in expanded_op_qubits:
@@ -1787,8 +1819,6 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 f"{len(subroutine_def.arguments)} but got {len(statement.arguments)} in call"
             )
 
-        function_ops = copy.deepcopy(subroutine_def.body)
-
         duplicate_qubit_detect_map = {}
         qubit_transform_map = {}  # {(formal arg, idx) : (actual arg, idx)}
         formal_qreg_size_map = {}
@@ -1855,7 +1885,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
             # Better to just evaluate that expression and assign that value later to
             # the formal argument
             if actual_arg_name:
-                if actual_arg_name in self._qreg_size_map:
+                if actual_arg_name in self._global_qreg_size_map:
                     self._print_err_location(statement.span)
                     raise Qasm3ConversionError(
                         f"Expecting classical argument for '{formal_arg.name.name}'. "
@@ -1910,7 +1940,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
             formal_qreg_size_map[formal_reg_name] = formal_qubit_size
 
             # we expect that actual arg is qubit type only
-            if actual_arg_name not in self._qreg_size_map:
+            if actual_arg_name not in self._global_qreg_size_map:
                 self._print_err_location(statement.span)
                 raise Qasm3ConversionError(
                     f"Expecting qubit argument for '{formal_reg_name}'."
@@ -1919,7 +1949,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
             self._label_scope_level[self._curr_scope].add(formal_reg_name)
 
             actual_qids, actual_qubits_size = self._get_target_qubits(
-                actual_arg, self._qreg_size_map, actual_arg_name
+                actual_arg, self._global_qreg_size_map, actual_arg_name
             )
 
             if formal_qubit_size != actual_qubits_size:
@@ -1962,26 +1992,24 @@ class BasicQasmVisitor(ProgramElementVisitor):
         for var in classical_vars:
             self._add_var_in_scope(var)
 
-        for function_op in function_ops:
+        # push qubit transform maps
+        self._function_qreg_size_map.append(formal_qreg_size_map)
+        self._function_qreg_transform_map.append(qubit_transform_map)
+
+        for function_op in subroutine_def.body:
             if isinstance(function_op, ReturnStatement):
-                return_statement = function_op
+                return_statement = copy.deepcopy(function_op)
                 break
-
-            if isinstance(function_op, (QuantumGate, QuantumReset, QuantumBarrier)):
-                function_op.qubits = self._transform_function_qubits(
-                    function_op, formal_qreg_size_map, qubit_transform_map
-                )
-            # TODO: need to extend this for other blocks too - for, if, while, etc.
-            elif isinstance(function_op, QuantumMeasurementStatement):
-                # TODO :handle measurement
-                pass
-
-            self.visit_statement(function_op)
+            self.visit_statement(copy.deepcopy(function_op))
 
         return_value = self._evaluate_expression(return_statement.expression)
         return_value = self._validate_return_statement(
             subroutine_def, return_statement, return_value
         )
+
+        # remove qubit transformations
+        self._function_qreg_transform_map.pop()
+        self._function_qreg_size_map.pop()
 
         self._restore_context()
         del self._label_scope_level[self._curr_scope]
@@ -2047,11 +2075,11 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 f"Unsupported aliasing {statement} not supported at the moment"
             )
 
-        if aliased_reg_name not in self._qreg_size_map:
+        if aliased_reg_name not in self._global_qreg_size_map:
             self._print_err_location(statement.span)
             raise Qasm3ConversionError(f"Qubit register {aliased_reg_name} not found for aliasing")
 
-        aliased_reg_size = self._qreg_size_map[aliased_reg_name]
+        aliased_reg_size = self._global_qreg_size_map[aliased_reg_name]
         if isinstance(value, Identifier):  # "let alias = q;"
             for i in range(aliased_reg_size):
                 self._qubit_labels[f"{alias_reg_name}_{i}"] = self._qubit_labels[
@@ -2063,7 +2091,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 qids = self._extract_values_from_discrete_set(value.index)
                 for i, qid in enumerate(qids):
                     self._validate_register_index(
-                        qid, self._qreg_size_map[aliased_reg_name], qubit=True
+                        qid, self._global_qreg_size_map[aliased_reg_name], qubit=True
                     )
                     self._qubit_labels[f"{alias_reg_name}_{i}"] = self._qubit_labels[
                         f"{aliased_reg_name}_{qid}"
@@ -2079,7 +2107,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
             elif isinstance(value.index[0], IntegerLiteral):  # "let alias = q[0];"
                 qid = value.index[0].value
                 self._validate_register_index(
-                    qid, self._qreg_size_map[aliased_reg_name], qubit=True
+                    qid, self._global_qreg_size_map[aliased_reg_name], qubit=True
                 )
                 self._qubit_labels[f"{alias_reg_name}_0"] = value.index[0].value
                 alias_reg_size = 1
@@ -2093,7 +2121,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
                     self._qubit_labels[f"{alias_reg_name}_{i}"] = qid
                 alias_reg_size = len(qids)
 
-        self._qreg_size_map[alias_reg_name] = alias_reg_size
+        self._global_qreg_size_map[alias_reg_name] = alias_reg_size
 
         _log.debug("Added labels for aliasing '%s'", target)
 

--- a/tests/qasm3_qir/converter/declarations/test_classical.py
+++ b/tests/qasm3_qir/converter/declarations/test_classical.py
@@ -90,6 +90,30 @@ def test_scalar_assignments():
     check_attributes(generated_qir, 0, 0)
 
 
+def test_example_qir():
+    qasm3_string = """
+    OPENQASM 3;
+
+    // static initialization 
+    array[int[32], 3, 2] arr_int = { {1, 2}, {3, 4}, {5, 6} };
+    array[float[32], 3, 2] arr_float32 = { {1.0, 2.0}, {3.0, 4.0}, {5.0, 6.0} };
+
+    // assignment of individual elements 
+    int a = 2;
+    arr_int[1][1] = a; // arr_int = { {1, 2}, {3, 2}, {5, 6} }
+
+    // array elements in expressions
+    float[32] b = arr_float32[1][1] * 3.1415; // b = 4.0*3.1415 = 12.566
+
+    qubit q;
+    rx(b) q; // rx(12.566) is applied on qubit q
+    """
+    result = qasm3_to_qir(qasm3_string)
+    generated_qir = str(result).splitlines()
+    check_attributes(generated_qir, 1, 0)
+    check_single_qubit_rotation_op(generated_qir, 1, [0], [12.566], "rx")
+
+
 # 4. Scalar value assignment
 def test_scalar_value_assignment():
     """Test assigning variable values from other variables"""

--- a/tests/qasm3_qir/converter/test_barrier.py
+++ b/tests/qasm3_qir/converter/test_barrier.py
@@ -45,6 +45,26 @@ def test_barrier():
     check_barrier(generated_qir, expected_barriers=4)
 
 
+def test_barrier_in_function():
+    """Test that a barrier in a function is correctly parsed."""
+    qasm_str = """OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(qubit[4] a) {
+        barrier a;
+        return;
+    }
+    qubit[4] q;
+    my_function(q);
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 4, 0)
+    check_barrier(generated_qir, 1)
+
+
 def test_incorrect_barrier():
     subset = """
     OPENQASM 3;

--- a/tests/qasm3_qir/converter/test_loop.py
+++ b/tests/qasm3_qir/converter/test_loop.py
@@ -18,6 +18,11 @@ import pytest
 
 from qbraid_qir.qasm3 import qasm3_to_qir
 from qbraid_qir.qasm3.visitor import Qasm3ConversionError
+from tests.qir_utils import (
+    check_attributes,
+    check_single_qubit_gate_op,
+    check_single_qubit_rotation_op,
+)
 
 EXAMPLE_WITHOUT_LOOP = """
 OPENQASM 3.0;
@@ -269,6 +274,115 @@ def test_convert_qasm3_for_loop_discrete_set():
     )
     assert str(qir_expected) == str(qir_from_loop)
     assert str(qir_from_loop) == EXAMPLE_QIR_OUTPUT
+
+
+def test_function_executed_in_loop():
+    """Test that a function executed in a loop is correctly parsed."""
+    qasm_str = """OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(qubit q_arg, float[32] b) {
+        rx(b) q_arg;
+        return;
+    }
+    qubit[5] q;
+
+    int[32] n = 2;
+    float[32] b = 3.14;
+
+    for int i in [0:n] {
+        my_function(q[i], i*b);
+    }
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 5, 0)
+    check_single_qubit_rotation_op(generated_qir, 3, list(range(3)), [0, 3.14, 2 * 3.14], "rx")
+
+
+def test_loop_inside_function():
+    """Test that a function with a loop is correctly parsed."""
+    qasm_str = """OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(qubit[3] q2) {
+        for int[32] i in [0:2] {
+            h q2[i];
+        }
+        return;
+    }
+    qubit[3] q1;
+    my_function(q1);
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 3, 0)
+    check_single_qubit_gate_op(generated_qir, 3, [0, 1, 2], "h")
+
+
+def test_function_in_nested_loop():
+    """Test that a function executed in a nested loop is correctly parsed."""
+    qasm_str = """OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(qubit q_arg, float[32] b) {
+        rx(b) q_arg;
+        return;
+    }
+    qubit[5] q;
+
+    int[32] n = 2;
+    float[32] b = 3.14;
+
+    for int i in [0:n] {
+        for int j in [0:n] {
+            my_function(q[i], j*b);
+        }
+    }
+
+    my_function(q[0], 2*b);
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 5, 0)
+    check_single_qubit_rotation_op(
+        generated_qir,
+        9,
+        [0, 0, 0, 1, 1, 1, 2, 2, 2, 0],
+        [0, 3.14, 2 * 3.14, 0, 3.14, 2 * 3.14, 0, 3.14, 2 * 3.14, 2 * 3.14],
+        "rx",
+    )
+
+
+@pytest.mark.skip(reason="Not implemented nested functions yet")
+def test_loop_in_nested_function_call():
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+    def my_function_1(qubit q1, int[32] a){
+        for int[32] i in [0:2]{
+            rx(a*i) q1;
+        }
+    }
+
+    def my_function_2(qubit q2, int[32] b){
+        my_function_1(q2, b);
+    }
+
+    qubit q;
+    my_function_2(q, 3);
+    """
+    result = qasm3_to_qir(qasm3_string)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 1, 0)
+    check_single_qubit_rotation_op(generated_qir, 3, [0, 0, 0], [0, 3, 6], "rx")
 
 
 def test_convert_qasm3_for_loop_unsupported_type():

--- a/tests/qasm3_qir/converter/test_reset.py
+++ b/tests/qasm3_qir/converter/test_reset.py
@@ -43,6 +43,25 @@ def test_reset_operations():
     check_resets(generated_qir, expected_resets=5, qubit_list=[0, 2, 5, 3, 4])
 
 
+def test_reset_inside_function():
+    """Test that a qubit reset inside a function is correctly parsed."""
+    qasm_str = """OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(qubit a) {
+        reset a;
+        return;
+    }
+    qubit[3] q;
+    my_function(q[1]);
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+    check_attributes(generated_qir, 3, 0)
+    check_resets(generated_qir, 1, [1])
+
+
 def test_incorrect_resets():
     undeclared = """
     OPENQASM 3;

--- a/tests/qasm3_qir/converter/test_subroutine.py
+++ b/tests/qasm3_qir/converter/test_subroutine.py
@@ -214,6 +214,87 @@ def test_function_call_with_custom_gate():
     check_single_qubit_rotation_op(generated_qir, 2, [0, 0], [3.14, 6.28], "rx")
 
 
+def test_function_call_from_within_fn():
+    """Test that a function call from within another function is correctly converted."""
+    qasm_str = """OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(qubit q) {
+        h q;
+        return;
+    }
+
+    def my_function_2(qubit[2] q) {
+        my_function(q[1]);
+        return;
+    }
+    qubit[2] q;
+    my_function_2(q);
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+    check_attributes(generated_qir, 2, 0)
+    check_single_qubit_gate_op(generated_qir, 1, [1], "h")
+
+
+def test_subroutine_inside_switch():
+    """Test that a subroutine inside a switch statement is correctly parsed."""
+    qasm_str = """OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(qubit q, float[32] b) {
+        rx(b) q;
+        return;
+    }
+
+    qubit[2] q;
+    int i = 1;
+    float[32] r = 3.14;
+
+    switch(i) {
+        case 1 {
+            my_function(q[0], r);
+        }
+        default {
+            x q;
+        }
+    }
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 2, 0)
+    check_single_qubit_rotation_op(generated_qir, 1, [0], [3.14], "rx")
+
+
+def test_function_executed_in_loop():
+    """Test that a function executed in a loop is correctly parsed."""
+    qasm_str = """OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(qubit q_arg, float[32] b) {
+        rx(b) q_arg;
+        return;
+    }
+    qubit[5] q;
+
+    int[32] n = 3;
+    float[32] b = 3.14;
+
+    for int i in [0:n] {
+        my_function(q[i], i*b);
+    }
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 5, 0)
+    check_single_qubit_rotation_op(generated_qir, 3, list(range(3)), [0, 3.14, 2 * 3.14], "rx")
+
+
 @pytest.mark.skip(reason="Not implemented for loop statement updates in scope")
 def test_function_with_loop():
     """Test that a function with a loop is correctly parsed."""

--- a/tests/qasm3_qir/converter/test_switch.py
+++ b/tests/qasm3_qir/converter/test_switch.py
@@ -219,7 +219,6 @@ def test_nested_switch():
     default {
         z q;
     }
-    
     }
     """
 

--- a/tests/qasm3_qir/converter/test_switch.py
+++ b/tests/qasm3_qir/converter/test_switch.py
@@ -20,7 +20,11 @@ import pytest
 
 from qbraid_qir.qasm3 import qasm3_to_qir
 from qbraid_qir.qasm3.exceptions import Qasm3ConversionError
-from tests.qir_utils import check_attributes, check_single_qubit_gate_op
+from tests.qir_utils import (
+    check_attributes,
+    check_single_qubit_gate_op,
+    check_single_qubit_rotation_op,
+)
 
 
 def test_switch():
@@ -227,6 +231,37 @@ def test_nested_switch():
 
     check_attributes(generated_qir, 1, 0)
     check_single_qubit_gate_op(generated_qir, 1, [0], "y")
+
+
+def test_subroutine_inside_switch():
+    """Test that a subroutine inside a switch statement is correctly parsed."""
+    qasm_str = """OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(qubit q, float[32] b) {
+        rx(b) q;
+        return;
+    }
+
+    qubit[2] q;
+    int i = 1;
+    float[32] r = 3.14;
+
+    switch(i) {
+        case 1 {
+            my_function(q[0], r);
+        }
+        default {
+            x q;
+        }
+    }
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 2, 0)
+    check_single_qubit_rotation_op(generated_qir, 1, [0], [3.14], "rx")
 
 
 @pytest.mark.parametrize("invalid_type", ["float", "bool", "bit"])


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #133 

## Summary of changes

#### Fix subroutines inside for loop
- The current state of subroutines was not correctly handling the case when the subroutines were being called inside a block scope i.e. `for` or `switch` 
- As soon as a block scope started, a `BLOCK` scope was pushed. Now, if a function was called inside this `BLOCK` scope, a new `FUNCTION` scope was pushed before the start of classical and quantum argument processing.
- The error was that the `FUNCTION` scope should have only been pushed after the processing of the arguments. Since this push happened before, we were not able to detect the `BLOCK` scope variables in the newly pushed `FUNCTION` scope. 
- Example - 

```qasm
OPENQASM 3.0;
include "stdgates.inc";

def my_function(qubit q_arg, float[32] b) {
        rx(b) q_arg; // function scope 
        return;
    }
qubit[5] q;
int[32] n = 3; // global scope 
float[32] b = 3.14; // global scope 
for int i in [0:n] {
    my_function(q[i], i*b); // called in block scope 
}
```
- In the above example, as soon as the line `my_function(q[i], i*b);` is parsed, we push a `FUNCTION` scope which forgets about the variables `i` and `b` needed for correct argument mapping. 
- This was changed in this PR with some further simplification of variable processing logic. 


#### Fix loops inside subroutines
- Since qubits are passed by reference inside a subroutine, we had to update the formal arguments with the respective actual argument. In case of quantum args, these were the **qubit registers**
- We were only catering to the directly present `QuantumGate`, `QuantumReset` and `QuantumBarrier` while doing this mapping. But, this ignored these elements present inside blocks like the `for` or the `switch` statements 

- **Supported** 
```qasm3 
OPENQASM 3;
include "stdgates.inc";

def my_function(int[32] a, qubit q_arg) {
    h q_arg; // direct call
    rx (a) q_arg; // direct call
    return;
}
qubit[3] q;
my_function(2, q[2]);
my_function(1, q[1]);
my_function(0, q[0]);
```
- **Raised Error** 
```qasm3 
OPENQASM 3;
include "stdgates.inc";

def my_function(qubit[3] q2) {
    for int[32] i in [0:2] {
        // indirect call, inside block scope
        h q2[i]; // need to map q2 bits to q1 bits
    }
    return;
}
qubit[3] q1;
my_function(q1);
```

- To support these, we had to use a qubit transformation map at the visitor level. 
- This holds a "stack" of qubit transformation maps, each belonging to a particular function call. 
- Now, instead of transforming the qubits inside the body of the `_visit_function_call` method , we directly transform them inside the visitors of these constructs. Eg. For `QuantumReset` we transform the qubits whenever the `_visit_reset` is called. 
- This enables us to support arbitrary formal argument references in case of qubits
