### PR TITLE
Add measurement basis change support for `cirq_qir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Types of changes:
 ## [Unreleased]
 
 ### ➕  New Features 
+* Add support for pauli measurement operators in `cirq` converter ( [#144](https://github.com/qBraid/qbraid-qir/pull/144) )
 
 ### 🌟  Improvements 
 

--- a/qbraid_qir/cirq/visitor.py
+++ b/qbraid_qir/cirq/visitor.py
@@ -146,7 +146,7 @@ class BasicCirqVisitor(CircuitElementVisitor):
         else:
             pyqir_func, op_str = map_cirq_op_to_pyqir_callable(operation)
 
-            if op_str == "MEASURE":
+            if op_str.startswith("measure"):
                 handle_measurement(pyqir_func)
             elif op_str in ["Rx", "Ry", "Rz"]:
                 pyqir_func(self._builder, operation.gate._rads, *qubits)

--- a/tests/cirq_qir/test_cirq_preprocess.py
+++ b/tests/cirq_qir/test_cirq_preprocess.py
@@ -15,6 +15,7 @@ import cirq
 import numpy as np
 import pytest
 
+from qbraid_qir.cirq.exceptions import CirqConversionError
 from qbraid_qir.cirq.passes import preprocess_circuit
 
 # pylint: disable=redefined-outer-name
@@ -56,3 +57,13 @@ def test_empty_circuit_conversion():
     circuit = cirq.Circuit()
     converted_circuit = preprocess_circuit(circuit)
     assert len(converted_circuit.all_qubits()) == 0, "Converted empty circuit should have no qubits"
+
+
+def test_multi_qubit_measurement_error():
+    qubits = cirq.LineQubit.range(3)
+    circuit = cirq.Circuit()
+    ps = cirq.X(qubits[0]) * cirq.Y(qubits[1]) * cirq.X(qubits[2])
+    meas_gates = cirq.measure_single_paulistring(ps)
+    circuit.append(meas_gates)
+    with pytest.raises(CirqConversionError):
+        preprocess_circuit(circuit)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #138 

## Summary of changes
- `cirq` supports measurements in the `Pauli` bases X, Y and Z. This is done either via the [measure_paulistring_terms](https://quantumai.google/reference/python/cirq/measure_paulistring_terms) or [measure_single_paulistring](https://quantumai.google/reference/python/cirq/measure_single_paulistring) methods. These two methods allow users to add `PauliZ`, `PauliX` and `PauliY` measurement operations to the circuit which can be done on single or multiple qubits.
- As mentioned in the issue, I transformed the X and Y measurements to the Z basis and thus applied the Z basis measurement. 
- I am currently not sure if the multi-qubit measurement operators are equivalent to the tensor product of equivalent single qubit ops. For this, I have added a todo in the `qbraid_qir/cirq/opsets.py`. 

Will need some discussion on this @ryanhill1 