### PR TITLE
Add implementation for `sizeof` in openqasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Types of changes:
 
 ### ➕  New Features 
 * Add support for pauli measurement operators in `cirq` converter ( [#144](https://github.com/qBraid/qbraid-qir/pull/144) )
+* Add support for `sizeof` operator in `openqasm` converter ( [#146](https://github.com/qBraid/qbraid-qir/pull/146) )
 
 ### 🌟  Improvements 
 * Re-factor the `BasicQasmVisitor` and improve modularity ( [#142](https://github.com/qBraid/qbraid-qir/pull/142) )

--- a/qbraid_qir/qasm3/elements.py
+++ b/qbraid_qir/qasm3/elements.py
@@ -69,7 +69,7 @@ class Variable:
         name: str,
         base_type,
         base_size: int,
-        dims: list[int] = None,
+        dims: Optional[list[int]] = None,
         value: Optional[Union[int, float, list]] = None,
         is_constant: bool = False,
     ):

--- a/tests/qasm3_qir/converter/test_sizeof.py
+++ b/tests/qasm3_qir/converter/test_sizeof.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2023 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Module containing unit tests for QASM3 to QIR conversion functions.
+
+"""
+import pytest
+
+from qbraid_qir.qasm3 import qasm3_to_qir
+from qbraid_qir.qasm3.exceptions import Qasm3ConversionError
+from tests.qir_utils import check_attributes, check_single_qubit_rotation_op
+
+
+def test_simple_sizeof():
+    """Test sizeof over an array"""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    array[int[32], 3, 2] my_ints;
+
+    const uint[32] size0 = sizeof(my_ints); // this is 3 and valid 
+
+    int[32] size1 = sizeof(my_ints); // this is 3 
+
+    int[32] size2 = sizeof(my_ints, 1); // this is 2
+
+    int[32] size3 = sizeof(my_ints, 0); // this is 3
+    qubit[2] q;
+
+    rx(size0) q[0];
+    rx(size1) q[0];
+    rx(size2) q[1];
+    rx(size3) q[1];
+    """
+
+    result = qasm3_to_qir(qasm3_string)
+    generated_qir = str(result).splitlines()
+    check_attributes(generated_qir, 2, 0)
+
+    check_single_qubit_rotation_op(generated_qir, 4, [0, 0, 1, 1], [3, 3, 2, 3], "rx")
+
+
+def test_sizeof_multiple_types():
+    """Test sizeof over an array of bit, int and float"""
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    array[bit, 3, 2] my_bits;
+    array[int[32], 3, 2] my_ints;
+    array[float[64], 3, 2] my_floats;
+
+    int[32] size1 = sizeof(my_bits); // this is 3 
+
+    int[32] size2 = sizeof(my_ints, 1); // this is 2
+
+    int[32] size3 = sizeof(my_floats, 0); // this is 3 too
+    qubit[2] q;
+
+    rx(size1) q[0];
+    rx(size2) q[1];
+    rx(size3) q[1];
+    """
+
+    result = qasm3_to_qir(qasm3_string)
+    generated_qir = str(result).splitlines()
+    check_attributes(generated_qir, 2, 0)
+
+    check_single_qubit_rotation_op(generated_qir, 2, [0, 1, 1], [3, 2, 3], "rx")
+
+
+def test_unsupported_target():
+    """Test sizeof over index expressions"""
+    with pytest.raises(Qasm3ConversionError, match=r"Unsupported target type .*"):
+        qasm3_string = """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        array[int[32], 3, 2] my_ints;
+
+        int[32] size1 = sizeof(my_ints[0]); // this is invalid
+        """
+        qasm3_to_qir(qasm3_string)
+
+
+def test_sizeof_on_non_array():
+    """Test sizeof on a non-array"""
+    with pytest.raises(
+        Qasm3ConversionError, match="Invalid sizeof usage, variable my_int is not an array."
+    ):
+        qasm3_string = """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        int[32] my_int = 3;
+
+        int[32] size1 = sizeof(my_int); // this is invalid
+        """
+        qasm3_to_qir(qasm3_string)
+
+
+def test_out_of_bounds_reference():
+    """Test sizeof on an out of bounds reference"""
+    with pytest.raises(
+        Qasm3ConversionError, match="Index 3 out of bounds for array my_ints with 2 dimensions"
+    ):
+        qasm3_string = """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        array[int[32], 3, 2] my_ints;
+
+        int[32] size1 = sizeof(my_ints, 3); // this is invalid
+        """
+        qasm3_to_qir(qasm3_string)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #143 
## Summary of changes
- An initial implementation of the `sizeof` operator is added 
- The `sizeof` operator is confined to `array` in openqasm 
- [Reference example](https://github.com/openqasm/openqasm/blob/9f0bd0b90aa848557934e11b1f880bde0d0160dd/examples/arrays.qasm#L65)