### PR TITLE
`array` support for QASM3 subroutines

### DIFF
--- a/qbraid_qir/qasm3/elements.py
+++ b/qbraid_qir/qasm3/elements.py
@@ -18,6 +18,7 @@ from abc import ABCMeta, abstractmethod
 from enum import Enum
 from typing import Optional, Union
 
+import numpy as np
 from openqasm3.ast import BitType, ClassicalDeclaration, Program, QubitDeclaration, Statement
 from pyqir import Context as qirContext
 from pyqir import Module
@@ -60,6 +61,7 @@ class Variable:
         dims (list[int]): Dimensions of the variable.
         value (Optional[Union[int, float, list]]): Value of the variable.
         is_constant (bool): Flag indicating if the variable is constant.
+        readonly(bool): Flag indicating if the variable is readonly.
 
     """
 
@@ -70,8 +72,9 @@ class Variable:
         base_type,
         base_size: int,
         dims: Optional[list[int]] = None,
-        value: Optional[Union[int, float, list]] = None,
+        value: Optional[Union[int, float, np.ndarray]] = None,
         is_constant: bool = False,
+        readonly: bool = False,
     ):
         self.name = name
         self.base_type = base_type
@@ -79,6 +82,7 @@ class Variable:
         self.dims = dims
         self.value = value
         self.is_constant = is_constant
+        self.readonly = readonly
 
 
 class _ProgramElement(metaclass=ABCMeta):

--- a/qbraid_qir/qasm3/expressions.py
+++ b/qbraid_qir/qasm3/expressions.py
@@ -245,7 +245,8 @@ class Qasm3ExprEvaluator:
                 if reqd_type == Qasm3FloatType and isinstance(expression, FloatLiteral):
                     return expression.value
                 raise_qasm3_error(
-                    f"Invalid type {type(expression)} for required type {reqd_type}",
+                    f"Invalid value {expression.value} with type {type(expression)} "
+                    f"for required type {reqd_type}",
                     Qasm3ConversionError,
                     expression.span,
                 )

--- a/qbraid_qir/qasm3/maps.py
+++ b/qbraid_qir/qasm3/maps.py
@@ -667,24 +667,25 @@ VARIABLE_TYPE_MAP = {
     ComplexType: complex,
     # AngleType: None,  # not sure
 }
-VARIABLE_TYPE_STR = {
-    BitType: "bit",
-    IntType: "int",
-    UintType: "uint",
-    BoolType: "bool",
-    FloatType: "float",
-    ComplexType: "complex",
-    AngleType: "angle",
-}
 
 # Reference: https://openqasm.com/language/types.html#allowed-casts
 VARIABLE_TYPE_CAST_MAP = {
-    BoolType: [int, float, bool],
-    IntType: [bool, int, float],
-    BitType: [bool, int],
-    UintType: [bool, int, float],
-    FloatType: [bool, int, float],
-    AngleType: [float],
+    BoolType: (int, float, bool, np.int64, np.float64, np.bool_),
+    IntType: (bool, int, float, np.int64, np.float64, np.bool_),
+    BitType: (bool, int, np.int64, np.bool_),
+    UintType: (bool, int, float, np.int64, np.uint64, np.float64, np.bool_),
+    FloatType: (bool, int, float, np.int64, np.float64, np.bool_),
+    AngleType: (float, np.float64),
+}
+
+ARRAY_TYPE_MAP = {
+    BitType: np.bool_,
+    IntType: np.int64,
+    UintType: np.uint64,
+    FloatType: np.float64,
+    ComplexType: np.complex128,
+    BoolType: np.bool_,
+    AngleType: np.float64,
 }
 
 

--- a/qbraid_qir/qasm3/maps.py
+++ b/qbraid_qir/qasm3/maps.py
@@ -667,6 +667,15 @@ VARIABLE_TYPE_MAP = {
     ComplexType: complex,
     # AngleType: None,  # not sure
 }
+VARIABLE_TYPE_STR = {
+    BitType: "bit",
+    IntType: "int",
+    UintType: "uint",
+    BoolType: "bool",
+    FloatType: "float",
+    ComplexType: "complex",
+    AngleType: "angle",
+}
 
 # Reference: https://openqasm.com/language/types.html#allowed-casts
 VARIABLE_TYPE_CAST_MAP = {

--- a/qbraid_qir/qasm3/subroutines.py
+++ b/qbraid_qir/qasm3/subroutines.py
@@ -1,0 +1,363 @@
+# Copyright (C) 2024 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Module containing the class for validating QASM3 subroutines.
+
+"""
+from typing import Optional, Union
+
+from openqasm3.ast import (
+    AccessControl,
+    ArrayReferenceType,
+    Identifier,
+    IndexExpression,
+    IntType,
+    QubitDeclaration,
+)
+
+from .analyzer import Qasm3Analyzer
+from .elements import Variable
+from .exceptions import raise_qasm3_error
+from .expressions import Qasm3ExprEvaluator
+from .transformer import Qasm3Transformer
+from .validator import Qasm3Validator
+
+# pylint: disable=too-many-arguments, too-many-locals, too-many-branches
+
+
+class Qasm3SubroutineProcessor:
+    """Class for processing QASM3 subroutines."""
+
+    visitor_obj = None
+
+    @classmethod
+    def set_visitor_obj(cls, visitor_obj) -> None:
+        cls.visitor_obj = visitor_obj
+
+    @staticmethod
+    def get_fn_actual_arg_name(actual_arg: Union[Identifier, IndexExpression]) -> Optional[str]:
+        actual_arg_name = None
+        if isinstance(actual_arg, Identifier):
+            actual_arg_name = actual_arg.name
+        elif isinstance(actual_arg, IndexExpression):
+            if isinstance(actual_arg.collection, Identifier):
+                actual_arg_name = actual_arg.collection.name
+            else:
+                actual_arg_name = (
+                    actual_arg.collection.collection.name  # type: ignore[attr-defined]
+                )
+        return actual_arg_name
+
+    @classmethod
+    def process_classical_arg(cls, formal_arg, actual_arg, fn_name, span):
+        actual_arg_name = Qasm3SubroutineProcessor.get_fn_actual_arg_name(actual_arg)
+
+        if isinstance(formal_arg.type, ArrayReferenceType):
+            return cls._process_classical_arg_by_reference(
+                formal_arg, actual_arg, actual_arg_name, fn_name, span
+            )
+        return cls._process_classical_arg_by_value(
+            formal_arg, actual_arg, actual_arg_name, fn_name, span
+        )
+
+    @classmethod
+    def _process_classical_arg_by_value(
+        cls, formal_arg, actual_arg, actual_arg_name, fn_name, span
+    ):
+        """
+        Process the classical argument for a function call.
+
+        Args:
+            formal_arg (FormalArgument): The formal argument of the function.
+            actual_arg (ActualArgument): The actual argument passed to the function.
+            actual_arg_name (str): The name of the actual argument.
+            fn_name (str): The name of the function.
+            span (Span): The span of the function call.
+
+        Raises:
+            Qasm3ConversionError: If the actual argument is a qubit register instead
+                                of a classical argument.
+            Qasm3ConversionError: If the actual argument is an undefined variable.
+        """
+        # 1. variable mapping is equivalent to declaring the variable
+        #     with the formal argument name and doing classical assignment
+        #     in the scope of the function
+        if actual_arg_name:  # actual arg is a variable not literal
+            if actual_arg_name in cls.visitor_obj._global_qreg_size_map:
+                raise_qasm3_error(
+                    f"Expecting classical argument for '{formal_arg.name.name}'. "
+                    f"Qubit register '{actual_arg_name}' found for function '{fn_name}'",
+                    span=span,
+                )
+
+            # 2. as we have pushed the scope for fn, we need to check in parent
+            #    scope for argument validation
+            if not cls.visitor_obj._check_in_scope(actual_arg_name):
+                raise_qasm3_error(
+                    f"Undefined variable '{actual_arg_name}' used"
+                    f" for function call '{fn_name}'",
+                    span=span,
+                )
+        actual_arg_value = Qasm3ExprEvaluator.evaluate_expression(actual_arg)
+
+        # save this value to be updated later in scope
+        return Variable(
+            name=formal_arg.name.name,
+            base_type=formal_arg.type,
+            base_size=Qasm3ExprEvaluator.evaluate_expression(formal_arg.type.size),
+            dims=None,
+            value=actual_arg_value,
+            is_constant=False,
+        )
+
+    @classmethod
+    def _process_classical_arg_by_reference(
+        cls, formal_arg, actual_arg, actual_arg_name, fn_name, span
+    ):
+        """Process the classical args by reference in the QASM3 visitor.
+            Currently being used for array references only.
+
+        Args:
+            formal_arg (Qasm3Expression): The formal argument of the function.
+            actual_arg (Qasm3Expression): The actual argument passed to the function.
+            actual_arg_name (str): The name of the actual argument.
+            fn_name (str): The name of the function.
+            span (Span): The span of the function call.
+
+        Raises:
+            Qasm3ConversionError: If the actual argument is -
+                                - not an array.
+                                - an undefined variable.
+                                - a qubit register.
+                                - a literal.
+                                - having type mismatch with the formal argument.
+        """
+
+        formal_arg_base_size = Qasm3ExprEvaluator.evaluate_expression(
+            formal_arg.type.base_type.size
+        )
+        array_expected_type_msg = (
+            "Expecting type 'array["
+            f"{formal_arg.type.base_type.__class__.__name__.lower().removesuffix('type')}"
+            f"[{formal_arg_base_size}],...]' for '{formal_arg.name.name}'"
+            f" in function '{fn_name}'. "
+        )
+
+        if actual_arg_name is None:
+            raise_qasm3_error(
+                array_expected_type_msg
+                + f"Literal {Qasm3ExprEvaluator.evaluate_expression(actual_arg)} "
+                + "found in function call",
+                span=span,
+            )
+
+        if actual_arg_name in cls.visitor_obj._global_qreg_size_map:
+            raise_qasm3_error(
+                array_expected_type_msg
+                + f"Qubit register '{actual_arg_name}' found for function call",
+                span=span,
+            )
+
+        # verify actual argument is defined in the parent scope of function call
+        if not cls.visitor_obj._check_in_scope(actual_arg_name):
+            raise_qasm3_error(
+                f"Undefined variable '{actual_arg_name}' used for function call '{fn_name}'",
+                span=span,
+            )
+
+        array_reference = cls.visitor_obj._get_from_visible_scope(actual_arg_name)
+        actual_type_string = Qasm3Transformer.get_type_string(array_reference)
+
+        # ensure that actual argument is an array
+        if not array_reference.dims:
+            raise_qasm3_error(
+                array_expected_type_msg
+                + f"Variable '{actual_arg_name}' has type '{actual_type_string}'.",
+                span=span,
+            )
+
+        # The base types of the elements in array should match
+        actual_arg_type = array_reference.base_type
+        actual_arg_size = array_reference.base_size
+
+        if formal_arg.type.base_type != actual_arg_type or formal_arg_base_size != actual_arg_size:
+            raise_qasm3_error(
+                array_expected_type_msg
+                + f"Variable '{actual_arg_name}' has type '{actual_type_string}'.",
+                span=span,
+            )
+
+        # The dimensions passed in the formal arg should be
+        # within limits of the actual argument
+
+        # need to ensure that we have a positive integer as dimension
+        actual_dimensions = array_reference.dims
+        formal_dimensions_raw = formal_arg.type.dimensions
+        # 1. Either we  will have #dim = <<some integer>>
+        if not isinstance(formal_dimensions_raw, list):
+            num_formal_dimensions = Qasm3ExprEvaluator.evaluate_expression(
+                formal_dimensions_raw, reqd_type=IntType, const_expr=True
+            )
+        # 2. or we will have a list of the dimensions in the formal arg
+        else:
+            num_formal_dimensions = len(formal_dimensions_raw)
+
+        if num_formal_dimensions <= 0:
+            raise_qasm3_error(
+                f"Invalid number of dimensions {num_formal_dimensions}"
+                f" for '{formal_arg.name.name}' in function '{fn_name}'",
+                span=span,
+            )
+
+        if num_formal_dimensions > len(actual_dimensions):
+            raise_qasm3_error(
+                f"Dimension mismatch for '{formal_arg.name.name}' in function '{fn_name}'. "
+                f"Expected {num_formal_dimensions} dimensions but"
+                f" variable '{actual_arg_name}' has {len(actual_dimensions)}",
+                span=span,
+            )
+        formal_dimensions = []
+
+        # we need to ensure that the dimensions are within the limits AND valid integers
+        if not isinstance(formal_dimensions_raw, list):
+            # the case when we have #dim identifier
+            formal_dimensions = actual_dimensions[:num_formal_dimensions]
+        else:
+            for idx, (formal_dim, actual_dim) in enumerate(
+                zip(formal_dimensions_raw, actual_dimensions)
+            ):
+                formal_dim = Qasm3ExprEvaluator.evaluate_expression(
+                    formal_dim, reqd_type=IntType, const_expr=True
+                )
+                if formal_dim <= 0:
+                    raise_qasm3_error(
+                        f"Invalid dimension size {formal_dim} for '{formal_arg.name.name}'"
+                        f" in function '{fn_name}'",
+                        span=span,
+                    )
+                if actual_dim < formal_dim:
+                    raise_qasm3_error(
+                        f"Dimension mismatch for '{formal_arg.name.name}'"
+                        f" in function '{fn_name}'. Expected dimension {idx} with size"
+                        f" >= {formal_dim} but got {actual_dim}",
+                        span=span,
+                    )
+                formal_dimensions.append(formal_dim)
+
+        readonly_arr = formal_arg.access == AccessControl.readonly
+        actual_array_view = array_reference.value
+        if isinstance(actual_arg, IndexExpression):
+            _, actual_indices = Qasm3Analyzer.analyze_index_expression(actual_arg)
+            actual_indices = Qasm3Analyzer.analyze_classical_indices(
+                actual_indices, array_reference
+            )
+            actual_array_view = Qasm3Analyzer.find_array_element(
+                array_reference.value, actual_indices
+            )
+
+        return Variable(
+            name=formal_arg.name.name,
+            base_type=formal_arg.type.base_type,
+            base_size=formal_arg_base_size,
+            dims=formal_dimensions,
+            value=actual_array_view,  # this is the VIEW of the actual array
+            readonly=readonly_arr,
+        )
+
+    @classmethod
+    def process_quantum_arg(
+        cls,
+        formal_arg,
+        actual_arg,
+        formal_qreg_size_map,
+        duplicate_qubit_map,
+        qubit_transform_map,
+        fn_name,
+        span,
+    ):
+        """
+        Process a quantum argument in the QASM3 visitor.
+
+        Args:
+            formal_arg (Qasm3Expression): The formal argument in the function signature.
+            actual_arg (Qasm3Expression): The actual argument passed to the function.
+            formal_qreg_size_map (dict): The map of formal quantum register sizes.
+            duplicate_qubit_map (dict): The map of duplicate qubit registers.
+            qubit_transform_map (dict): The map of qubit register transformations.
+            fn_name (str): The name of the function.
+            span (Span): The span of the function call.
+
+        Returns:
+            list: The list of actual qubit ids.
+
+        Raises:
+            Qasm3ConversionError: If there is a mismatch in the quantum register size or
+                                  if the actual argument is not a qubit register.
+
+        """
+        actual_arg_name = Qasm3SubroutineProcessor.get_fn_actual_arg_name(actual_arg)
+        formal_reg_name = formal_arg.name.name
+        formal_qubit_size = Qasm3ExprEvaluator.evaluate_expression(
+            formal_arg.size, reqd_type=IntType, const_expr=True
+        )
+        if formal_qubit_size is None:
+            formal_qubit_size = 1
+        if formal_qubit_size <= 0:
+            raise_qasm3_error(
+                f"Invalid qubit size {formal_qubit_size} for variable '{formal_reg_name}'"
+                f" in function '{fn_name}'",
+                span=span,
+            )
+        formal_qreg_size_map[formal_reg_name] = formal_qubit_size
+
+        # we expect that actual arg is qubit type only
+        # note that we ONLY check in global scope as
+        # we always map the qubit arguments to the global scope
+        if actual_arg_name not in cls.visitor_obj._global_qreg_size_map:
+            raise_qasm3_error(
+                f"Expecting qubit argument for '{formal_reg_name}'. "
+                f"Qubit register '{actual_arg_name}' not found for function '{fn_name}'",
+                span=span,
+            )
+        cls.visitor_obj._label_scope_level[cls.visitor_obj._curr_scope].add(formal_reg_name)
+
+        actual_qids, actual_qubits_size = Qasm3Transformer.get_target_qubits(
+            actual_arg, cls.visitor_obj._global_qreg_size_map, actual_arg_name
+        )
+
+        if formal_qubit_size != actual_qubits_size:
+            raise_qasm3_error(
+                f"Qubit register size mismatch for function '{fn_name}'. "
+                f"Expected {formal_qubit_size} in variable '{formal_reg_name}' "
+                f"but got {actual_qubits_size}",
+                span=span,
+            )
+
+        if not Qasm3Validator.validate_unique_qubits(
+            duplicate_qubit_map, actual_arg_name, actual_qids
+        ):
+            raise_qasm3_error(
+                f"Duplicate qubit argument for register '{actual_arg_name}' "
+                f"in function call for '{fn_name}'",
+                span=span,
+            )
+
+        for idx, qid in enumerate(actual_qids):
+            qubit_transform_map[(formal_reg_name, idx)] = (actual_arg_name, qid)
+
+        return Variable(
+            name=formal_reg_name,
+            base_type=QubitDeclaration,
+            base_size=formal_qubit_size,
+            dims=None,
+            value=None,
+            is_constant=False,
+        )

--- a/qbraid_qir/qasm3/transformer.py
+++ b/qbraid_qir/qasm3/transformer.py
@@ -29,8 +29,10 @@ from openqasm3.ast import (
     UnaryExpression,
 )
 
+from .elements import Variable
 from .exceptions import raise_qasm3_error
 from .expressions import Qasm3ExprEvaluator
+from .maps import VARIABLE_TYPE_STR
 from .validator import Qasm3Validator
 
 # mypy: disable-error-code="attr-defined, union-attr"
@@ -226,3 +228,20 @@ class Qasm3Transformer:
             )
 
         return transformed_qubits
+
+    @staticmethod
+    def get_type_string(variable: Variable) -> str:
+        """Get the type string for a variable."""
+        base_type = variable.base_type
+        base_size = variable.base_size
+        dims = variable.dims
+        is_array = dims and len(dims) > 0
+        type_str = "" if not is_array else "array["
+
+        type_str += VARIABLE_TYPE_STR[base_type.__class__]
+        if base_size:
+            type_str += f"[{base_size}]"
+
+        if is_array:
+            type_str += f", {', '.join([str(dim) for dim in dims])}]"
+        return type_str

--- a/qbraid_qir/qasm3/validator.py
+++ b/qbraid_qir/qasm3/validator.py
@@ -14,6 +14,7 @@ Module with utility functions for QASM3 visitor
 """
 from typing import Any, Optional, Union
 
+import numpy as np
 from openqasm3.ast import ArrayType, ClassicalDeclaration
 from openqasm3.ast import IntType as Qasm3IntType
 from openqasm3.ast import QuantumGate, QuantumGateDefinition, ReturnStatement, SubroutineDefinition
@@ -161,26 +162,26 @@ class Qasm3Validator:
 
     @staticmethod
     def validate_array_assignment_values(
-        variable: Variable, dimensions: list[int], values: list
+        variable: Variable, dimensions: list[int], values: np.ndarray
     ) -> None:
         """Validate the assignment of values to an array variable.
 
         Args:
             variable (Variable): The variable to assign to.
             dimensions (list[int]): The dimensions of the array.
-            values (list[Any]): The values to assign.
+            values (np.ndarray[Any]): The values to assign.
 
         Raises:
             Qasm3ConversionError: If the values are not of the correct type.
         """
         # recursively check the array
-        if len(values) != dimensions[0]:
+        if values.shape[0] != dimensions[0]:
             raise_qasm3_error(
                 f"Invalid dimensions for array assignment to variable {variable.name}. "
-                f"Expected {dimensions[0]} but got {len(values)}",
+                f"Expected {dimensions[0]} but got {values.shape[0]}",
             )
         for i, value in enumerate(values):
-            if isinstance(value, list):
+            if isinstance(value, np.ndarray):
                 Qasm3Validator.validate_array_assignment_values(variable, dimensions[1:], value)
             else:
                 if len(dimensions) != 1:

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -20,6 +20,7 @@ from abc import ABCMeta, abstractmethod
 from collections import deque
 from typing import Any, Optional, Union
 
+import numpy as np
 import openqasm3.ast as qasm3_ast
 import pyqir
 import pyqir._native
@@ -30,12 +31,14 @@ from .elements import Context, InversionOp, Qasm3Module, Variable
 from .exceptions import Qasm3ConversionError, raise_qasm3_error
 from .expressions import Qasm3ExprEvaluator
 from .maps import (
+    ARRAY_TYPE_MAP,
     CONSTANTS_MAP,
     MAX_ARRAY_DIMENSIONS,
     SWITCH_BLACKLIST_STMTS,
     map_qasm_inv_op_to_pyqir_callable,
     map_qasm_op_to_pyqir_callable,
 )
+from .subroutines import Qasm3SubroutineProcessor
 from .transformer import Qasm3Transformer
 from .validator import Qasm3Validator
 
@@ -109,7 +112,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
 
     def _init_utilities(self):
         """Initialize the utilities for the visitor."""
-        for class_obj in [Qasm3Transformer, Qasm3ExprEvaluator]:
+        for class_obj in [Qasm3Transformer, Qasm3ExprEvaluator, Qasm3SubroutineProcessor]:
             class_obj.set_visitor_obj(self)
 
     @property
@@ -903,10 +906,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 final_dimensions.append(dim_value)
                 num_elements *= dim_value
 
-            init_value = None
-            for dim in reversed(final_dimensions):
-                assert isinstance(dim, int)
-                init_value = [init_value for _ in range(dim)]
+            init_value = np.full(final_dimensions, None)
 
         if statement.init_expression:
             if isinstance(statement.init_expression, qasm3_ast.ArrayLiteral):
@@ -936,7 +936,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
         variable = Variable(var_name, base_type, base_size, final_dimensions, init_value)
 
         if statement.init_expression:
-            if isinstance(init_value, list):
+            if isinstance(init_value, np.ndarray):
                 assert variable.dims is not None
                 Qasm3Validator.validate_array_assignment_values(variable, variable.dims, init_value)
             else:
@@ -971,11 +971,6 @@ class BasicQasmVisitor(ProgramElementVisitor):
         # rvalue will be an evaluated value (scalar, list)
         # if rvalue is a list, we want a copy of it
         rvalue = statement.rvalue
-        rvar_name = None
-        if isinstance(rvalue, qasm3_ast.Identifier):
-            rvar_name = rvalue.name
-        if isinstance(rvar_name, qasm3_ast.Identifier):
-            rvar_name = rvar_name.name
         rvalue_raw = Qasm3ExprEvaluator.evaluate_expression(
             rvalue
         )  # consists of scope check and index validation
@@ -983,18 +978,12 @@ class BasicQasmVisitor(ProgramElementVisitor):
         # cast + validation
         # rhs is a scalar
         rvalue_eval = None
-        if not isinstance(rvalue_raw, list):
+        if not isinstance(rvalue_raw, np.ndarray):
             rvalue_eval = Qasm3Validator.validate_variable_assignment_value(
                 lvar, rvalue_raw  # type: ignore[arg-type]
             )
         else:  # rhs is a list
-
-            def _get_list_dimensions(lst):
-                if isinstance(lst, list):
-                    return [len(lst)] + _get_list_dimensions(lst[0])
-                return []
-
-            rvalue_dimensions = _get_list_dimensions(rvalue_raw)
+            rvalue_dimensions = list(rvalue_raw.shape)
 
             # validate that the values inside rvar are valid for lvar
             Qasm3Validator.validate_array_assignment_values(
@@ -1003,6 +992,12 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 values=rvalue_raw,  # type: ignore[arg-type]
             )
             rvalue_eval = rvalue_raw
+
+        if lvar.readonly:  # type: ignore[union-attr]
+            raise_qasm3_error(
+                f"Assignment to readonly variable '{lvar_name}' not allowed" " in function call",
+                span=statement.span,
+            )
 
         # lvalue will be the variable which will HOLD this value
         if isinstance(lvalue, qasm3_ast.IndexedIdentifier):
@@ -1020,14 +1015,13 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 indices=validated_l_indices,
                 value=rvalue_eval,
             )
-
         else:
             lvar.value = rvalue_eval  # type: ignore[union-attr]
         self._update_var_in_scope(lvar)  # type: ignore[arg-type]
 
     def _evaluate_array_initialization(
         self, array_literal: qasm3_ast.ArrayLiteral, dimensions: list[int], base_type: Any
-    ) -> list:
+    ) -> np.ndarray:
         """Evaluate an array initialization.
 
         Args:
@@ -1036,20 +1030,18 @@ class BasicQasmVisitor(ProgramElementVisitor):
             base_type (Any): The base type of the array.
 
         Returns:
-            list: The evaluated array initialization.
+            np.ndarray: The evaluated array initialization.
         """
         init_values = []
-
         for value in array_literal.values:
             if isinstance(value, qasm3_ast.ArrayLiteral):
-                init_values.append(
-                    self._evaluate_array_initialization(value, dimensions[1:], base_type)
-                )
+                nested_array = self._evaluate_array_initialization(value, dimensions[1:], base_type)
+                init_values.append(nested_array)
             else:
                 eval_value = Qasm3ExprEvaluator.evaluate_expression(value)
                 init_values.append(eval_value)
 
-        return init_values
+        return np.array(init_values, dtype=ARRAY_TYPE_MAP[base_type.__class__])
 
     def _visit_branching_statement(self, statement: qasm3_ast.BranchingStatement) -> None:
         """Visit a branching statement element.
@@ -1210,313 +1202,25 @@ class BasicQasmVisitor(ProgramElementVisitor):
         formal_qreg_size_map: dict = {}
 
         quantum_vars, classical_vars = [], []
-
-        def _process_classical_arg_by_value(formal_arg, actual_arg, actual_arg_name):
-            """
-            Process the classical argument for a function call.
-
-            Args:
-                formal_arg (FormalArgument): The formal argument of the function.
-                actual_arg (ActualArgument): The actual argument passed to the function.
-                actual_arg_name (str): The name of the actual argument.
-
-            Raises:
-                Qasm3ConversionError: If the actual argument is a qubit register instead
-                                    of a classical argument.
-                Qasm3ConversionError: If the actual argument is an undefined variable.
-            """
-            # 1. variable mapping is equivalent to declaring the variable
-            #     with the formal argument name and doing classical assignment
-            #     in the scope of the function
-            if actual_arg_name:  # actual arg is a variable not literal
-                if actual_arg_name in self._global_qreg_size_map:
-                    raise_qasm3_error(
-                        f"Expecting classical argument for '{formal_arg.name.name}'. "
-                        f"Qubit register '{actual_arg_name}' found for function '{fn_name}'",
-                        span=statement.span,
-                    )
-
-                # 2. as we have pushed the scope for fn, we need to check in parent
-                #    scope for argument validation
-                if not self._check_in_scope(actual_arg_name):
-                    raise_qasm3_error(
-                        f"Undefined variable '{actual_arg_name}' used for function '{fn_name}'",
-                        span=statement.span,
-                    )
-
-            # NOTE: actual_argument can also be an EXPRESSION
-            # Better to just evaluate that expression and assign that value later to
-            # the formal argument
-            actual_arg_value = Qasm3ExprEvaluator.evaluate_expression(actual_arg)
-
-            # save this value to be updated later in scope
-            classical_vars.append(
-                Variable(
-                    formal_arg.name.name,
-                    formal_arg.type,
-                    Qasm3ExprEvaluator.evaluate_expression(formal_arg.type.size),
-                    None,
-                    actual_arg_value,
-                    False,
-                )
-            )
-
-        def _process_classical_arg_by_reference(formal_arg, actual_arg, actual_arg_name):
-            """Process the classical args by reference in the QASM3 visitor.
-               Currently being used for array references only.
-
-            Args:
-                formal_arg (Qasm3Expression): The formal argument of the function.
-                actual_arg (Qasm3Expression): The actual argument passed to the function.
-                actual_arg_name (str): The name of the actual argument.
-
-            Raises:
-                Qasm3ConversionError: If the actual argument is -
-                                    - not an array.
-                                    - an undefined variable.
-                                    - a qubit register.
-                                    - a literal.
-                                    - having type mismatch with the formal argument.
-            """
-
-            formal_arg_type = formal_arg.type.base_type
-            formal_arg_base_size = Qasm3ExprEvaluator.evaluate_expression(
-                formal_arg.type.base_type.size
-            )
-            array_expected_type_msg = (
-                "Expecting array with base type "
-                f"'{formal_arg_type.__class__.__name__.lower().removesuffix('type')}"
-                f"[{formal_arg_base_size}]' for '{formal_arg.name.name}' in function '{fn_name}'. "
-            )
-
-            if actual_arg_name is None:
-                raise_qasm3_error(
-                    array_expected_type_msg
-                    + f"Literal {Qasm3ExprEvaluator.evaluate_expression(actual_arg)} "
-                    + "found in function call",
-                    span=statement.span,
-                )
-
-            if actual_arg_name in self._global_qreg_size_map:
-                raise_qasm3_error(
-                    array_expected_type_msg
-                    + f"Qubit register '{actual_arg_name}' found for function call",
-                    span=statement.span,
-                )
-
-            # verify actual argument is defined in the parent scope of function call
-            if not self._check_in_scope(actual_arg_name):
-                raise_qasm3_error(
-                    f"Undefined variable '{actual_arg_name}' used for function call '{fn_name}'",
-                    span=statement.span,
-                )
-
-            array_reference = self._get_from_visible_scope(actual_arg_name)
-            actual_type_string = Qasm3Transformer.get_type_string(array_reference)
-
-            # ensure that actual argument is an array
-            if not array_reference.dims:
-                raise_qasm3_error(
-                    array_expected_type_msg
-                    + f"Variable '{actual_arg_name}' has type '{actual_type_string}'.",
-                    span=statement.span,
-                )
-
-            # The base types of the elements in array should match
-            actual_arg_type = array_reference.base_type
-            actual_arg_size = array_reference.base_size
-
-            if formal_arg_type != actual_arg_type or formal_arg_base_size != actual_arg_size:
-                raise_qasm3_error(
-                    array_expected_type_msg
-                    + f"Variable '{actual_arg_name}' has type '{actual_type_string}'.",
-                    span=statement.span,
-                )
-
-            # The dimensions passed in the formal arg should be
-            # within limits of the actual argument
-
-            # need to ensure that we have a positive integer as dimension
-            actual_dimensions = array_reference.dims
-            formal_dimensions_raw = formal_arg.type.dimensions
-            # 1. Either we  will have #dim = <<some integer>>
-            if not isinstance(formal_dimensions_raw, list):
-                num_formal_dimensions = Qasm3ExprEvaluator.evaluate_expression(
-                    formal_dimensions_raw, reqd_type=qasm3_ast.IntType, const_expr=True
-                )
-            # 2. or we will have a list of the dimensions in the formal arg
-            else:
-                num_formal_dimensions = len(formal_dimensions_raw)
-            if num_formal_dimensions <= 0:
-                raise_qasm3_error(
-                    f"Invalid number of dimensions {num_formal_dimensions}"
-                    f" for '{formal_arg.name.name}' in function '{fn_name}'",
-                    span=statement.span,
-                )
-
-            if num_formal_dimensions > len(actual_dimensions):
-                raise_qasm3_error(
-                    f"Dimension mismatch for '{formal_arg.name.name}' in function '{fn_name}'. "
-                    f"Expected {num_formal_dimensions} dimensions but"
-                    f" variable '{actual_arg_name}' has {len(actual_dimensions)}",
-                    span=statement.span,
-                )
-            formal_dimensions = []
-            # we need to ensure that the dimensions are within the limits AND valid integers
-            if isinstance(formal_dimensions_raw, list):
-                for idx, (formal_dim, actual_dim) in enumerate(
-                    zip(formal_dimensions_raw, actual_dimensions)
-                ):
-                    formal_dim = Qasm3ExprEvaluator.evaluate_expression(
-                        formal_dim, reqd_type=qasm3_ast.IntType, const_expr=True
-                    )
-                    if formal_dim <= 0:
-                        raise_qasm3_error(
-                            f"Invalid dimension size {formal_dim} for '{formal_arg.name.name}'"
-                            f"in function '{fn_name}'",
-                            span=statement.span,
-                        )
-                    if actual_dim < formal_dim:
-                        raise_qasm3_error(
-                            f"Dimension mismatch for '{formal_arg.name.name}'"
-                            f" in function '{fn_name}'. Expected dimension {idx} with size"
-                            f" >= {formal_dim} but got {actual_dim}",
-                            span=statement.span,
-                        )
-                    formal_dimensions.append(formal_dim)
-
-            readonly_arr = formal_arg.access == qasm3_ast.AccessControl.readonly
-            if isinstance(actual_arg, qasm3_ast.IndexExpression):
-                _, actual_indices = Qasm3Analyzer.analyze_index_expression(actual_arg)
-                # actual_indices are in openqasm format, let's convert to int
-                actual_indices = Qasm3Analyzer.analyze_classical_indices(
-                    actual_indices, array_reference
-                )
-
-                # now we have validated int format indices for the actual argument array
-                # we need to make a new variable with the formal argument name and given
-                # dimensions AND assign it the value of the actual argument array to those indices
-
-                # NOTE: if we have the #dim identifier, we use the dimensions of the actual arg
-                # being passed
-
-                # we need to create a new variable with the formal argument name and the given
-                # dimensions
-                formal_array = Variable(
-                    name=formal_arg.name.name,
-                    base_type=formal_arg_type,
-                    base_size=formal_arg_base_size,
-                    dims=formal_dimensions,
-                    value=None,
-                )
-                # if len(formal_dimensions) > 0:
-            # array[int[8], 6, 6, 6, 6 ] bb;
-            # bb[0, 1:2, 0:3, 2:5] -> formal arg - def my_func( array[int[8], 2, 4, 4] arr_arg)
-
-            # maybe look into numpy slicing ?
-            # we want to create an identical numpy array - perform that op on the numpy array
-
-            # add numpy as a dependency and use it to slice the array
-
-            # TODO... 
-            
-            elif isinstance(actual_arg, qasm3_ast.Identifier):
-                # full array is passed
-                pass
-
-        def _process_quantum_arg(formal_arg, actual_arg, formal_reg_name, actual_arg_name):
-            """
-            Process a quantum argument in the QASM3 visitor.
-
-            Args:
-                formal_arg (Qasm3Expression): The formal argument in the function signature.
-                actual_arg (Qasm3Expression): The actual argument passed to the function.
-                formal_reg_name (str): The name of the formal quantum register.
-                actual_arg_name (str): The name of the actual quantum register.
-
-            Returns:
-                list: The list of actual qubit ids.
-
-            Raises:
-                Qasm3ConversionError: If there is a mismatch in the quantum register size or
-                                      if the actual argument is not a qubit register.
-
-            """
-            formal_qubit_size = Qasm3ExprEvaluator.evaluate_expression(
-                formal_arg.size, reqd_type=qasm3_ast.IntType, const_expr=True
-            )
-            if formal_qubit_size is None:
-                formal_qubit_size = 1
-            if formal_qubit_size <= 0:
-                raise_qasm3_error(
-                    f"Invalid qubit size {formal_qubit_size} for variable '{formal_reg_name}'"
-                    f" in function '{fn_name}'",
-                    span=statement.span,
-                )
-            formal_qreg_size_map[formal_reg_name] = formal_qubit_size
-
-            # we expect that actual arg is qubit type only
-            # note that we ONLY check in global scope as
-            # we always map the qubit arguments to the global scope
-            if actual_arg_name not in self._global_qreg_size_map:
-                raise_qasm3_error(
-                    f"Expecting qubit argument for '{formal_reg_name}'. "
-                    f"Qubit register '{actual_arg_name}' not found for function '{fn_name}'",
-                    span=statement.span,
-                )
-            self._label_scope_level[self._curr_scope].add(formal_reg_name)
-
-            actual_qids, actual_qubits_size = Qasm3Transformer.get_target_qubits(
-                actual_arg, self._global_qreg_size_map, actual_arg_name
-            )
-
-            if formal_qubit_size != actual_qubits_size:
-                raise_qasm3_error(
-                    f"Qubit register size mismatch for function '{fn_name}'. "
-                    f"Expected {formal_qubit_size} in variable '{formal_reg_name}' "
-                    f"but got {actual_qubits_size}",
-                    span=statement.span,
-                )
-
-            quantum_vars.append(
-                Variable(
-                    formal_reg_name,
-                    qasm3_ast.QubitDeclaration,
-                    formal_qubit_size,
-                    None,
-                    None,
-                    False,
-                )
-            )
-
-            if not Qasm3Validator.validate_unique_qubits(
-                duplicate_qubit_detect_map, actual_arg_name, actual_qids
-            ):
-                raise_qasm3_error(
-                    f"Duplicate qubit argument for register '{actual_arg_name}' "
-                    f"in function call for '{fn_name}'",
-                    span=statement.span,
-                )
-
-            for idx, qid in enumerate(actual_qids):
-                qubit_transform_map[(formal_reg_name, idx)] = (actual_arg_name, qid)
-
         for actual_arg, formal_arg in zip(statement.arguments, subroutine_def.arguments):
-            actual_arg_name = None
-            if isinstance(actual_arg, qasm3_ast.Identifier):
-                actual_arg_name = actual_arg.name
-            elif isinstance(actual_arg, qasm3_ast.IndexExpression) and isinstance(
-                actual_arg.collection, qasm3_ast.Identifier
-            ):
-                actual_arg_name = actual_arg.collection.name
-
             if isinstance(formal_arg, qasm3_ast.ClassicalArgument):
-                if isinstance(formal_arg.type, qasm3_ast.ArrayReferenceType):
-                    _process_classical_arg_by_reference(formal_arg, actual_arg, actual_arg_name)
-                else:
-                    _process_classical_arg_by_value(formal_arg, actual_arg, actual_arg_name)
+                classical_vars.append(
+                    Qasm3SubroutineProcessor.process_classical_arg(
+                        formal_arg, actual_arg, fn_name, statement.span
+                    )
+                )
             else:
-                _process_quantum_arg(formal_arg, actual_arg, formal_arg.name.name, actual_arg_name)
+                quantum_vars.append(
+                    Qasm3SubroutineProcessor.process_quantum_arg(
+                        formal_arg,
+                        actual_arg,
+                        formal_qreg_size_map,
+                        duplicate_qubit_detect_map,
+                        qubit_transform_map,
+                        fn_name,
+                        statement.span,
+                    )
+                )
 
         self._push_scope({})
         self._curr_scope += 1
@@ -1533,16 +1237,18 @@ class BasicQasmVisitor(ProgramElementVisitor):
         self._function_qreg_size_map.append(formal_qreg_size_map)
         self._function_qreg_transform_map.append(qubit_transform_map)
 
+        return_statement = None
         for function_op in subroutine_def.body:
             if isinstance(function_op, qasm3_ast.ReturnStatement):
                 return_statement = copy.deepcopy(function_op)
                 break
             self.visit_statement(copy.deepcopy(function_op))
 
-        return_value = Qasm3ExprEvaluator.evaluate_expression(return_statement.expression)
-        return_value = Qasm3Validator.validate_return_statement(
-            subroutine_def, return_statement, return_value
-        )
+        if return_statement:
+            return_value = Qasm3ExprEvaluator.evaluate_expression(return_statement.expression)
+            return_value = Qasm3Validator.validate_return_statement(
+                subroutine_def, return_statement, return_value
+            )
 
         # remove qubit transformation map
         self._function_qreg_transform_map.pop()

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -956,47 +956,74 @@ class BasicQasmVisitor(ProgramElementVisitor):
             None
         """
         lvalue = statement.lvalue
-        var_name = lvalue.name
+        lvar_name = lvalue.name
+        if isinstance(lvar_name, qasm3_ast.Identifier):
+            lvar_name = lvar_name.name
 
-        if isinstance(var_name, qasm3_ast.Identifier):
-            var_name = var_name.name
-
-        var = self._get_from_visible_scope(var_name)
-
-        if var is None:  # we check for none here, so type errors are irrelevant afterwards
-            raise_qasm3_error(f"Undefined variable {var_name} in assignment", span=statement.span)
-
-        if var.is_constant:  # type: ignore[union-attr]
+        lvar = self._get_from_visible_scope(lvar_name)
+        if lvar is None:  # we check for none here, so type errors are irrelevant afterwards
+            raise_qasm3_error(f"Undefined variable {lvar_name} in assignment", span=statement.span)
+        if lvar.is_constant:  # type: ignore[union-attr]
             raise_qasm3_error(
-                f"Assignment to constant variable {var_name} not allowed", span=statement.span
+                f"Assignment to constant variable {lvar_name} not allowed", span=statement.span
             )
 
-        var_value = Qasm3ExprEvaluator.evaluate_expression(statement.rvalue)
-
-        # currently we support single array assignment only.
-        # TODO: range based assignment
+        # rvalue will be an evaluated value (scalar, list)
+        # if rvalue is a list, we want a copy of it
+        rvalue = statement.rvalue
+        rvar_name = None
+        if isinstance(rvalue, qasm3_ast.Identifier):
+            rvar_name = rvalue.name
+        if isinstance(rvar_name, qasm3_ast.Identifier):
+            rvar_name = rvar_name.name
+        rvalue_raw = Qasm3ExprEvaluator.evaluate_expression(
+            rvalue
+        )  # consists of scope check and index validation
 
         # cast + validation
-        var_value = Qasm3Validator.validate_variable_assignment_value(
-            var, var_value  # type: ignore[arg-type]
-        )
-        # handle assignment for arrays
+        # rhs is a scalar
+        rvalue_eval = None
+        if not isinstance(rvalue_raw, list):
+            rvalue_eval = Qasm3Validator.validate_variable_assignment_value(
+                lvar, rvalue_raw  # type: ignore[arg-type]
+            )
+        else:  # rhs is a list
+
+            def _get_list_dimensions(lst):
+                if isinstance(lst, list):
+                    return [len(lst)] + _get_list_dimensions(lst[0])
+                return []
+
+            rvalue_dimensions = _get_list_dimensions(rvalue_raw)
+
+            # validate that the values inside rvar are valid for lvar
+            Qasm3Validator.validate_array_assignment_values(
+                variable=lvar,  # type: ignore[arg-type]
+                dimensions=rvalue_dimensions,
+                values=rvalue_raw,  # type: ignore[arg-type]
+            )
+            rvalue_eval = rvalue_raw
+
+        # lvalue will be the variable which will HOLD this value
         if isinstance(lvalue, qasm3_ast.IndexedIdentifier):
             # stupid indices structure in openqasm :/
             if len(lvalue.indices[0]) > 1:  # type: ignore[arg-type]
-                indices = lvalue.indices[0]
+                l_indices = lvalue.indices[0]
             else:
-                indices = [idx[0] for idx in lvalue.indices]  # type: ignore[assignment, index]
+                l_indices = [idx[0] for idx in lvalue.indices]  # type: ignore[assignment, index]
 
-            validated_indices = Qasm3Analyzer.analyze_classical_indices(
-                indices, self._get_from_visible_scope(var_name)  # type: ignore[arg-type]
+            validated_l_indices = Qasm3Analyzer.analyze_classical_indices(
+                l_indices, lvar  # type: ignore[arg-type]
             )
             Qasm3Transformer.update_array_element(
-                var.value, validated_indices, var_value  # type: ignore[union-attr, arg-type]
+                multi_dim_arr=lvar.value,  # type: ignore[union-attr, arg-type]
+                indices=validated_l_indices,
+                value=rvalue_eval,
             )
+
         else:
-            var.value = var_value  # type: ignore[union-attr]
-        self._update_var_in_scope(var)  # type: ignore[arg-type]
+            lvar.value = rvalue_eval  # type: ignore[union-attr]
+        self._update_var_in_scope(lvar)  # type: ignore[arg-type]
 
     def _evaluate_array_initialization(
         self, array_literal: qasm3_ast.ArrayLiteral, dimensions: list[int], base_type: Any
@@ -1155,49 +1182,6 @@ class BasicQasmVisitor(ProgramElementVisitor):
 
         self._subroutine_defns[fn_name] = statement
 
-    def _get_target_qubits(self, target, qreg_size_map, target_name):
-        """Get the target qubits of a statement.
-
-        Args:
-            target (Any): The target of the statement.
-            qreg_size_map (dict[str: int]): The quantum register size map.
-            target_name (str): The name of the register.
-
-        Returns:
-            tuple: The target qubits.
-        """
-        target_qids = None
-        target_qubits_size = None
-
-        if isinstance(target, qasm3_ast.Identifier):  # "(q);"
-            target_qids = list(range(qreg_size_map[target_name]))
-            target_qubits_size = qreg_size_map[target_name]
-
-        elif isinstance(target, qasm3_ast.IndexExpression):
-            if isinstance(target.index, qasm3_ast.DiscreteSet):  # "(q[{0,1}]);"
-                target_qids = Qasm3Transformer.extract_values_from_discrete_set(target.index)
-                for qid in target_qids:
-                    Qasm3Validator.validate_register_index(
-                        qid, qreg_size_map[target_name], qubit=True
-                    )
-                target_qubits_size = len(target_qids)
-            elif isinstance(
-                target.index[0], (qasm3_ast.IntegerLiteral, qasm3_ast.Identifier)
-            ):  # "(q[0]); OR (q[i]);"
-                target_qids = [Qasm3ExprEvaluator.evaluate_expression(target.index[0])]
-                Qasm3Validator.validate_register_index(
-                    target_qids[0], qreg_size_map[target_name], qubit=True
-                )
-                target_qubits_size = 1
-            elif isinstance(target.index[0], qasm3_ast.RangeDefinition):  # "(q[0:1:2]);"
-                target_qids = Qasm3Transformer.get_qubits_from_range_definition(
-                    target.index[0],
-                    qreg_size_map[target_name],
-                    is_qubit_reg=True,
-                )
-                target_qubits_size = len(target_qids)
-        return target_qids, target_qubits_size
-
     # pylint: disable=too-many-locals, too-many-statements
     def _visit_function_call(self, statement: qasm3_ast.FunctionCall) -> None:
         """Visit a function call element.
@@ -1287,28 +1271,36 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 actual_arg_name (str): The name of the actual argument.
 
             Raises:
-                Qasm3ConversionError: If the actual argument is not an array.
-                Qasm3ConversionError: If the actual argument is an undefined variable.
+                Qasm3ConversionError: If the actual argument is -
+                                    - not an array.
+                                    - an undefined variable.
+                                    - a qubit register.
+                                    - a literal.
+                                    - having type mismatch with the formal argument.
             """
 
             formal_arg_type = formal_arg.type.base_type
-            formal_arg_size = Qasm3ExprEvaluator.evaluate_expression(formal_arg.type.base_type.size)
+            formal_arg_base_size = Qasm3ExprEvaluator.evaluate_expression(
+                formal_arg.type.base_type.size
+            )
             array_expected_type_msg = (
                 "Expecting array with base type "
                 f"'{formal_arg_type.__class__.__name__.lower().removesuffix('type')}"
-                f"[{formal_arg_size}]' for '{formal_arg.name.name}' in function '{fn_name}'. "
+                f"[{formal_arg_base_size}]' for '{formal_arg.name.name}' in function '{fn_name}'. "
             )
 
             if actual_arg_name is None:
                 raise_qasm3_error(
-                    array_expected_type_msg + f"Literal found in function call for '{fn_name}'",
+                    array_expected_type_msg
+                    + f"Literal {Qasm3ExprEvaluator.evaluate_expression(actual_arg)} "
+                    + "found in function call",
                     span=statement.span,
                 )
 
             if actual_arg_name in self._global_qreg_size_map:
                 raise_qasm3_error(
                     array_expected_type_msg
-                    + f"Qubit register '{actual_arg_name}' found for function '{fn_name}'",
+                    + f"Qubit register '{actual_arg_name}' found for function call",
                     span=statement.span,
                 )
 
@@ -1334,7 +1326,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
             actual_arg_type = array_reference.base_type
             actual_arg_size = array_reference.base_size
 
-            if formal_arg_type != actual_arg_type or formal_arg_size != actual_arg_size:
+            if formal_arg_type != actual_arg_type or formal_arg_base_size != actual_arg_size:
                 raise_qasm3_error(
                     array_expected_type_msg
                     + f"Variable '{actual_arg_name}' has type '{actual_type_string}'.",
@@ -1344,9 +1336,93 @@ class BasicQasmVisitor(ProgramElementVisitor):
             # The dimensions passed in the formal arg should be
             # within limits of the actual argument
 
-            # TODO...
+            # need to ensure that we have a positive integer as dimension
+            actual_dimensions = array_reference.dims
+            formal_dimensions_raw = formal_arg.type.dimensions
+            # 1. Either we  will have #dim = <<some integer>>
+            if not isinstance(formal_dimensions_raw, list):
+                num_formal_dimensions = Qasm3ExprEvaluator.evaluate_expression(
+                    formal_dimensions_raw, reqd_type=qasm3_ast.IntType, const_expr=True
+                )
+            # 2. or we will have a list of the dimensions in the formal arg
+            else:
+                num_formal_dimensions = len(formal_dimensions_raw)
+            if num_formal_dimensions <= 0:
+                raise_qasm3_error(
+                    f"Invalid number of dimensions {num_formal_dimensions}"
+                    f" for '{formal_arg.name.name}' in function '{fn_name}'",
+                    span=statement.span,
+                )
+
+            if num_formal_dimensions > len(actual_dimensions):
+                raise_qasm3_error(
+                    f"Dimension mismatch for '{formal_arg.name.name}' in function '{fn_name}'. "
+                    f"Expected {num_formal_dimensions} dimensions but"
+                    f" variable '{actual_arg_name}' has {len(actual_dimensions)}",
+                    span=statement.span,
+                )
+            formal_dimensions = []
+            # we need to ensure that the dimensions are within the limits AND valid integers
+            if isinstance(formal_dimensions_raw, list):
+                for idx, (formal_dim, actual_dim) in enumerate(
+                    zip(formal_dimensions_raw, actual_dimensions)
+                ):
+                    formal_dim = Qasm3ExprEvaluator.evaluate_expression(
+                        formal_dim, reqd_type=qasm3_ast.IntType, const_expr=True
+                    )
+                    if formal_dim <= 0:
+                        raise_qasm3_error(
+                            f"Invalid dimension size {formal_dim} for '{formal_arg.name.name}'"
+                            f"in function '{fn_name}'",
+                            span=statement.span,
+                        )
+                    if actual_dim < formal_dim:
+                        raise_qasm3_error(
+                            f"Dimension mismatch for '{formal_arg.name.name}'"
+                            f" in function '{fn_name}'. Expected dimension {idx} with size"
+                            f" >= {formal_dim} but got {actual_dim}",
+                            span=statement.span,
+                        )
+                    formal_dimensions.append(formal_dim)
 
             readonly_arr = formal_arg.access == qasm3_ast.AccessControl.readonly
+            if isinstance(actual_arg, qasm3_ast.IndexExpression):
+                _, actual_indices = Qasm3Analyzer.analyze_index_expression(actual_arg)
+                # actual_indices are in openqasm format, let's convert to int
+                actual_indices = Qasm3Analyzer.analyze_classical_indices(
+                    actual_indices, array_reference
+                )
+
+                # now we have validated int format indices for the actual argument array
+                # we need to make a new variable with the formal argument name and given
+                # dimensions AND assign it the value of the actual argument array to those indices
+
+                # NOTE: if we have the #dim identifier, we use the dimensions of the actual arg
+                # being passed
+
+                # we need to create a new variable with the formal argument name and the given
+                # dimensions
+                formal_array = Variable(
+                    name=formal_arg.name.name,
+                    base_type=formal_arg_type,
+                    base_size=formal_arg_base_size,
+                    dims=formal_dimensions,
+                    value=None,
+                )
+                # if len(formal_dimensions) > 0:
+            # array[int[8], 6, 6, 6, 6 ] bb;
+            # bb[0, 1:2, 0:3, 2:5] -> formal arg - def my_func( array[int[8], 2, 4, 4] arr_arg)
+
+            # maybe look into numpy slicing ?
+            # we want to create an identical numpy array - perform that op on the numpy array
+
+            # add numpy as a dependency and use it to slice the array
+
+            # TODO... 
+            
+            elif isinstance(actual_arg, qasm3_ast.Identifier):
+                # full array is passed
+                pass
 
         def _process_quantum_arg(formal_arg, actual_arg, formal_reg_name, actual_arg_name):
             """
@@ -1371,6 +1447,12 @@ class BasicQasmVisitor(ProgramElementVisitor):
             )
             if formal_qubit_size is None:
                 formal_qubit_size = 1
+            if formal_qubit_size <= 0:
+                raise_qasm3_error(
+                    f"Invalid qubit size {formal_qubit_size} for variable '{formal_reg_name}'"
+                    f" in function '{fn_name}'",
+                    span=statement.span,
+                )
             formal_qreg_size_map[formal_reg_name] = formal_qubit_size
 
             # we expect that actual arg is qubit type only
@@ -1384,7 +1466,7 @@ class BasicQasmVisitor(ProgramElementVisitor):
                 )
             self._label_scope_level[self._curr_scope].add(formal_reg_name)
 
-            actual_qids, actual_qubits_size = self._get_target_qubits(
+            actual_qids, actual_qubits_size = Qasm3Transformer.get_target_qubits(
                 actual_arg, self._global_qreg_size_map, actual_arg_name
             )
 

--- a/tests/qasm3_qir/converter/declarations/test_classical.py
+++ b/tests/qasm3_qir/converter/declarations/test_classical.py
@@ -287,7 +287,9 @@ def test_array_expressions():
     float[64] d = 6.7;
     bool f = true;
 
+
     arr_int[0][1] = a*a;
+    arr_int[1][0] = arr_int[0][1];
     arr_uint[0][1] = b*b;
     arr_float32[0][1] = c*c;
     arr_float64[0][1] = d*d;
@@ -343,24 +345,24 @@ def test_array_range_assignment():
     include "stdgates.inc";
 
     array[int[32], 3, 2] arr_int = { {1, 2}, {3, 4}, {5, 6} };
-    // array[uint[32], 3, 2] arr_uint = { {1, 2}, {3, 4}, {5, 6} };
-    // array[float[32], 3, 2] arr_float32 = { {1.0, 2.0}, {3.0, 4.0}, {5.0, 6.0} };
+    array[uint[32], 3, 2] arr_uint = { {1, 2}, {3, 4}, {5, 6} };
+    array[float[32], 3, 2] arr_float32 = { {1.0, 2.0}, {3.0, 4.0}, {5.0, 6.0} };
 
-    arr_int[0, 0:1] = arr_int[1, 0:1]; // array literals not allowed here 
-    // arr_uint[0:2, 1] = arr_uint[0:2, 0];
-    // arr_float32[0:2, 1] = arr_float32[0:2, 0];
+    arr_int[0, 0:1] = arr_int[1, 0:1]; 
+    arr_uint[0:2, 1] = arr_uint[0:2, 0];
+    arr_float32[0:2, 1] = arr_float32[0:2, 0];
 
     qubit q;
     rx(arr_int[0][1]) q;
-    // rx(arr_uint[0][1]) q;
-    // rx(arr_float32[1][1]) q;
+    rx(arr_uint[0][1]) q;
+    rx(arr_float32[1][1]) q;
 
     """
 
     result = qasm3_to_qir(qasm3_string)
     generated_qir = str(result).splitlines()
     check_attributes(generated_qir, 1, 0)
-    check_single_qubit_rotation_op(generated_qir, 1, [0], [4], "rx")
+    check_single_qubit_rotation_op(generated_qir, 3, [0, 0, 0], [4, 1, 3.0], "rx")
 
 
 @pytest.mark.parametrize("test_name", DECLARATION_TESTS.keys())

--- a/tests/qasm3_qir/converter/declarations/test_classical.py
+++ b/tests/qasm3_qir/converter/declarations/test_classical.py
@@ -335,6 +335,34 @@ def test_array_initializations():
     check_single_qubit_rotation_op(generated_qir, 5, [0, 0, 0, 0, 0], [2, 2, 2.0, 2.0, 0], "rx")
 
 
+def test_array_range_assignment():
+    """Test array range assignment"""
+
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    array[int[32], 3, 2] arr_int = { {1, 2}, {3, 4}, {5, 6} };
+    // array[uint[32], 3, 2] arr_uint = { {1, 2}, {3, 4}, {5, 6} };
+    // array[float[32], 3, 2] arr_float32 = { {1.0, 2.0}, {3.0, 4.0}, {5.0, 6.0} };
+
+    arr_int[0, 0:1] = arr_int[1, 0:1]; // array literals not allowed here 
+    // arr_uint[0:2, 1] = arr_uint[0:2, 0];
+    // arr_float32[0:2, 1] = arr_float32[0:2, 0];
+
+    qubit q;
+    rx(arr_int[0][1]) q;
+    // rx(arr_uint[0][1]) q;
+    // rx(arr_float32[1][1]) q;
+
+    """
+
+    result = qasm3_to_qir(qasm3_string)
+    generated_qir = str(result).splitlines()
+    check_attributes(generated_qir, 1, 0)
+    check_single_qubit_rotation_op(generated_qir, 1, [0], [4], "rx")
+
+
 @pytest.mark.parametrize("test_name", DECLARATION_TESTS.keys())
 def test_incorrect_declarations(test_name):
     qasm_input, error_message = DECLARATION_TESTS[test_name]

--- a/tests/qasm3_qir/converter/test_gates.py
+++ b/tests/qasm3_qir/converter/test_gates.py
@@ -56,7 +56,6 @@ def test_two_qubit_qasm3_gates(circuit_name, request):
     qasm3_string = request.getfixturevalue(circuit_name)
     result = qasm3_to_qir(qasm3_string)
 
-    print(result)
     generated_qir = str(result).splitlines()
     check_attributes(generated_qir, 2, 0)
     check_two_qubit_gate_op(generated_qir, 2, qubit_list, gate_name)

--- a/tests/qasm3_qir/converter/test_subroutine.py
+++ b/tests/qasm3_qir/converter/test_subroutine.py
@@ -66,8 +66,6 @@ def test_simple_function_call():
 
     result = qasm3_to_qir(qasm_str)
     generated_qir = str(result).splitlines()
-    for line in generated_qir:
-        print(line)
 
     check_attributes(generated_qir, 1, 1)
     check_single_qubit_rotation_op(generated_qir, 2, [0, 0], [3.14, 6.28], "rx")

--- a/tests/qasm3_qir/converter/test_subroutine_arrays.py
+++ b/tests/qasm3_qir/converter/test_subroutine_arrays.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2023 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Module containing unit tests for parsing, unrolling, and
+converting OpenQASM3 programs that contain arrays in subroutines.
+
+"""
+
+import pytest
+
+from qbraid_qir.qasm3 import qasm3_to_qir
+from qbraid_qir.qasm3.exceptions import Qasm3ConversionError
+from tests.qir_utils import check_attributes
+
+
+def test_simple_function_call():
+    """Test that a simple function call is correctly parsed."""
+    qasm_str = """OPENQASM 3.0;
+    include "stdgates.inc";
+
+    def my_function(qubit a, readonly array[int[8], 2, 2] my_arr) {
+        return;
+    }
+    qubit q;
+    array[int[8], 2, 2] arr;
+    my_function(q, arr);
+
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+    for line in generated_qir:
+        print(line)
+
+    check_attributes(generated_qir, 1, 0)
+
+
+def test_non_array_raises_error():
+    """Test that passing a non-array to an array parameter raises error."""
+    qasm_str = """OPENQASM 3.0;
+    include "stdgates.inc";
+
+    def my_function(qubit a, readonly array[int[8], 2, 2] my_arr) {
+        return;
+    }
+    qubit q;
+    int[8] arr;
+    my_function(q, arr);
+
+    """
+
+    with pytest.raises(
+        Qasm3ConversionError,
+        match=r"Expecting array with base type 'int\[8\]' for 'my_arr' in function 'my_function'."
+        r" Variable 'arr' has type 'int\[8\]'.",
+    ):
+        qasm3_to_qir(qasm_str)
+
+
+def test_literal_raises_error():
+    """Test that passing a literal to an array parameter raises error."""
+    qasm_str = """OPENQASM 3.0;
+    include "stdgates.inc";
+
+    def my_function(qubit a, readonly array[int[8], 2, 2] my_arr) {
+        return;
+    }
+    qubit q;
+    my_function(q, 5);
+
+    """
+
+    with pytest.raises(
+        Qasm3ConversionError,
+        match=r"Expecting array with base type 'int\[8\]' for 'my_arr' in function 'my_function'. "
+        r"Literal found in function call for 'my_function'",
+    ):
+        qasm3_to_qir(qasm_str)
+
+
+def test_type_mismatch_in_array():
+    """Test that passing an array of different type raises error."""
+    qasm_str = """OPENQASM 3.0;
+    include "stdgates.inc";
+
+    def my_function(qubit a, readonly array[int[8], 2, 2] my_arr) {
+        return;
+    }
+    qubit q;
+    array[float[32], 2, 2] arr;
+    my_function(q, arr);
+
+    """
+
+    with pytest.raises(
+        Qasm3ConversionError,
+        match=r"Expecting array with base type 'int\[8\]' for 'my_arr' in function 'my_function'."
+        r" Variable 'arr' has type 'array\[float\[32\], 2, 2\]'.",
+    ):
+        qasm3_to_qir(qasm_str)

--- a/tests/qasm3_qir/converter/test_subroutine_arrays.py
+++ b/tests/qasm3_qir/converter/test_subroutine_arrays.py
@@ -18,7 +18,7 @@ import pytest
 
 from qbraid_qir.qasm3 import qasm3_to_qir
 from qbraid_qir.qasm3.exceptions import Qasm3ConversionError
-from tests.qir_utils import check_attributes
+from tests.qir_utils import check_attributes, check_single_qubit_rotation_op
 
 
 def test_simple_function_call():
@@ -41,6 +41,114 @@ def test_simple_function_call():
     check_attributes(generated_qir, 1, 0)
 
 
+def test_passing_array_to_function():
+    """Test that passing an array to a function is correctly parsed."""
+    qasm_str = """OPENQASM 3.0;
+    include "stdgates.inc";
+
+    def my_function(readonly array[int[8], 2, 2] my_arr, qubit q) {
+        rx(my_arr[0][0]) q;
+        rx(my_arr[0][1]) q;
+        rx(my_arr[1][0]) q;
+        rx(my_arr[1][1]) q;
+
+        return;
+    }
+    qubit my_q;
+    array[int[8], 2, 2] arr = { {1, 2}, {3, 4} };
+    my_function(arr, my_q);
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 1, 0)
+    check_single_qubit_rotation_op(
+        generated_qir, 4, qubit_list=[0, 0, 0, 0], param_list=[1, 2, 3, 4], gate_name="rx"
+    )
+
+
+def test_passing_subarray_to_function():
+    """Test that passing a smaller subarray to a function is correctly parsed."""
+    qasm_str = """OPENQASM 3.0;
+    include "stdgates.inc";
+
+    def my_function(readonly array[int[8], 2, 2] my_arr, qubit q) {
+        rx(my_arr[0][0]) q;
+        rx(my_arr[0][1]) q;
+        return;
+    }
+    qubit my_q;
+    array[int[8], 4, 3] arr_1 = { {1, 2, 3}, {4, 5, 6}, {7, 8, 9}, {10, 11, 12} };
+    array[int[8], 2, 2] arr_2 = { {1, 2}, {3, 4} };
+    my_function(arr_1[1:2][1:2], my_q);
+    my_function(arr_2[0:1, :], my_q);
+
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 1, 0)
+    check_single_qubit_rotation_op(
+        generated_qir, 2, qubit_list=[0] * 4, param_list=[5, 6, 1, 2], gate_name="rx"
+    )
+
+
+def test_passing_array_with_dim_identifier():
+    """Test that passing an array with a dimension identifier is correctly parsed."""
+    qasm_str = """OPENQASM 3.0;
+    include "stdgates.inc";
+
+    def my_function(readonly array[int[8], #dim = 2] my_arr, qubit q) {
+        rx(my_arr[0][0]) q;
+        rx(my_arr[0][1]) q;
+        return;
+    }
+    qubit my_q;
+    array[int[8], 2, 2, 2] arr = { { {1, 2}, {3, 4} }, { {5, 6}, {7, 8} } };
+    my_function(arr[0, :, :], my_q);
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 1, 0)
+    check_single_qubit_rotation_op(
+        generated_qir, 2, qubit_list=[0] * 2, param_list=[1, 2], gate_name="rx"
+    )
+
+
+def test_pass_multiple_arrays_to_function():
+    """Test that passing multiple arrays to a function is correctly parsed."""
+    qasm_str = """OPENQASM 3.0;
+    include "stdgates.inc";
+
+    def my_function(readonly array[int[8], 2, 2] my_arr1, 
+                    readonly array[int[8], 2, 2] my_arr2, 
+                    qubit q) {
+        for int[8] i in [0:1] {
+            rx(my_arr1[i][0]) q;
+            rx(my_arr2[i][1]) q;
+        }
+
+        return;
+    }
+    qubit my_q;
+    array[int[8], 2, 2] arr_1 = { {1, 2}, {3, 4} };
+    array[int[8], 2, 2] arr_2 = { {5, 6}, {7, 8} };
+    my_function(arr_1, arr_2, my_q);
+    """
+
+    result = qasm3_to_qir(qasm_str)
+    generated_qir = str(result).splitlines()
+
+    check_attributes(generated_qir, 1, 0)
+    check_single_qubit_rotation_op(
+        generated_qir, 4, qubit_list=[0] * 4, param_list=[1, 6, 3, 8], gate_name="rx"
+    )
+
+
 def test_non_array_raises_error():
     """Test that passing a non-array to an array parameter raises error."""
     qasm_str = """OPENQASM 3.0;
@@ -57,7 +165,7 @@ def test_non_array_raises_error():
 
     with pytest.raises(
         Qasm3ConversionError,
-        match=r"Expecting array with base type 'int\[8\]' for 'my_arr' in function 'my_function'."
+        match=r"Expecting type 'array\[int\[8\],...\]' for 'my_arr' in function 'my_function'."
         r" Variable 'arr' has type 'int\[8\]'.",
     ):
         qasm3_to_qir(qasm_str)
@@ -78,7 +186,7 @@ def test_literal_raises_error():
 
     with pytest.raises(
         Qasm3ConversionError,
-        match=r"Expecting array with base type 'int\[8\]' for 'my_arr' in function 'my_function'."
+        match=r"Expecting type 'array\[int\[8\],...\]' for 'my_arr' in function 'my_function'."
         r" Literal 5 found in function call",
     ):
         qasm3_to_qir(qasm_str)
@@ -93,15 +201,15 @@ def test_type_mismatch_in_array():
         return;
     }
     qubit q;
-    array[float[32], 2, 2] arr;
+    array[uint[32], 2, 2] arr;
     my_function(q, arr);
 
     """
 
     with pytest.raises(
         Qasm3ConversionError,
-        match=r"Expecting array with base type 'int\[8\]' for 'my_arr' in function 'my_function'."
-        r" Variable 'arr' has type 'array\[float\[32\], 2, 2\]'.",
+        match=r"Expecting type 'array\[int\[8\],...\]' for 'my_arr' in function 'my_function'."
+        r" Variable 'arr' has type 'array\[uint\[32\], 2, 2\]'.",
     ):
         qasm3_to_qir(qasm_str)
 
@@ -165,7 +273,7 @@ def test_qubit_passed_as_array():
 
     with pytest.raises(
         Qasm3ConversionError,
-        match=r"Expecting array with base type 'int\[8\]' for 'my_arr' in function 'my_function'."
+        match=r"Expecting type 'array\[int\[8\],...\]' for 'my_arr' in function 'my_function'."
         r" Qubit register 'q' found for function call",
     ):
         qasm3_to_qir(qasm_str)
@@ -254,5 +362,44 @@ def test_extra_dimensions_for_array():
         Qasm3ConversionError,
         match=r"Dimension mismatch for 'my_arr' in function 'my_function'. "
         r"Expected dimension 0 with size >= 4 but got 2",
+    ):
+        qasm3_to_qir(qasm_str)
+
+
+def test_invalid_array_dimensions_formal_arg():
+    """Test that passing an array with invalid dimensions raises error."""
+    qasm_str = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(readonly array[int[32], -1, 2] a) {
+        return;
+    }
+    array[int[32], 1, 2] b;
+    my_function(b);
+    """
+    with pytest.raises(
+        Qasm3ConversionError,
+        match=r"Invalid dimension size -1 for 'a' in function 'my_function'",
+    ):
+        qasm3_to_qir(qasm_str)
+
+
+def test_invalid_array_mutation_for_readonly_arg():
+    """Test that mutating an array passed as readonly raises error."""
+    qasm_str = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    def my_function(readonly array[int[32], 1, 2] a) {
+        a[1][0] = 5;
+        return;
+    }
+    array[int[32], 1, 2] b;
+    my_function(b);
+    """
+    with pytest.raises(
+        Qasm3ConversionError,
+        match=r"Assignment to readonly variable 'a' not allowed in function call",
     ):
         qasm3_to_qir(qasm_str)

--- a/tests/qasm3_qir/converter/test_switch.py
+++ b/tests/qasm3_qir/converter/test_switch.py
@@ -383,7 +383,7 @@ def test_non_int_expression_case():
 
     with pytest.raises(
         Qasm3ConversionError,
-        match=r"Invalid type .* for required type <class 'openqasm3.ast.IntType'>",
+        match=r"Invalid value 4.3 with type .* for required type <class 'openqasm3.ast.IntType'>",
     ):
         qasm3_switch_program = base_invalid_program
         qasm3_to_qir(qasm3_switch_program, name="test")

--- a/tests/qasm3_qir/fixtures/subroutines.py
+++ b/tests/qasm3_qir/fixtures/subroutines.py
@@ -168,6 +168,20 @@ SUBROUTINE_INCORRECT_TESTS = {
         """,
         "Expecting qubit argument for 'q'. Qubit register 'b' not found for function 'my_function'",
     ),
+    "test_invalid_qubit_size": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        def my_function(qubit[-3] q) {
+            h q;
+            return;
+        }
+        qubit[4] q;
+        my_function(q);
+        """,
+        "Invalid qubit size -3 for variable 'q' in function 'my_function'",
+    ),
     "test_type_mismatch_for_function": (
         """
         OPENQASM 3;
@@ -197,7 +211,7 @@ SUBROUTINE_INCORRECT_TESTS = {
         """,
         r"Duplicate qubit argument for register 'q' in function call for 'my_function'",
     ),
-    "undefined_variable_in_actual_arg": (
+    "undefined_variable_in_actual_arg_1": (
         """
         OPENQASM 3;
         include "stdgates.inc";
@@ -209,6 +223,18 @@ SUBROUTINE_INCORRECT_TESTS = {
         qubit q;
         my_function(b);
         """,
-        "Undefined variable 'b' used for function 'my_function'",
+        "Undefined variable 'b' used for function call 'my_function'",
+    ),
+    "undefined_array_arg_in_function_call": (
+        """
+        OPENQASM 3;
+        include "stdgates.inc";
+
+        def my_function(readonly array[int[32], 1, 2] a) {
+            return;
+        }
+        my_function(b);
+        """,
+        "Undefined variable 'b' used for function call 'my_function'",
     ),
 }

--- a/tests/qasm3_qir/fixtures/variables.py
+++ b/tests/qasm3_qir/fixtures/variables.py
@@ -202,15 +202,6 @@ ASSIGNMENT_TESTS = {
             "<class 'openqasm3.ast.BitType'>"
         ),
     ),
-    "invalid_assignment_for_range": (
-        """
-        OPENQASM 3.0;
-        include "stdgates.inc";
-        array[int[32], 4, 4] my_arr;
-        my_arr[0, 1:1] = 3;
-        """,
-        "Range based indexing .* not supported for classical variable .*",
-    ),
     "int_out_of_range": (
         """
         OPENQASM 3.0;
@@ -267,6 +258,6 @@ ASSIGNMENT_TESTS = {
         array[int[32], 3] x;
         x[3] = 3;
         """,
-        "Index 3 out of bounds for dimension 1 of variable x",
+        "Index 3 out of bounds for dimension 0 of variable x",
     ),
 }

--- a/tests/qasm3_qir/fixtures/variables.py
+++ b/tests/qasm3_qir/fixtures/variables.py
@@ -248,7 +248,8 @@ ASSIGNMENT_TESTS = {
         array[int[32], 3] x;
         x[0.1] = 3;
         """,
-        "Unsupported index type <class 'openqasm3.ast.FloatLiteral'> for classical variable x",
+        "Invalid value 0.1 with type <class 'openqasm3.ast.FloatLiteral'> for "
+        "required type <class 'openqasm3.ast.IntType'>",
     ),
     "index_out_of_range": (
         """

--- a/tests/qir_utils.py
+++ b/tests/qir_utils.py
@@ -219,7 +219,6 @@ def check_single_qubit_gate_op(
         gate_call_id = (
             f"qis__{gate_name}" if "dg" not in gate_name else f"qis__{gate_name.removesuffix('dg')}"
         )
-        print(gate_call_id)
         if line.strip().startswith("call") and gate_call_id in line:
             assert line.strip() == single_op_call_string(
                 gate_name, qubit_list[q_id]
@@ -418,7 +417,6 @@ def _validate_complex_custom_op(entry_body: list[str]):
 
 def check_custom_qasm_gate_op(qir: list[str], test_type: str):
     entry_body = get_entry_point_body(qir)
-    print(entry_body)
     if test_type == "simple":
         _validate_simple_custom_op(entry_body)
     elif test_type == "nested":


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #132 

## Summary of changes
This pull request introduces support for array handling within subroutines. Users can now pass arrays as either mutable or readonly, enhancing the flexibility and functionality of subroutine definitions.
- [x] error checking
- [x] `readonly` support 
- [x] `mutable` support
- [x] unit tests

