### PR TITLE
Add semantic checker for qasm3

### DIFF
--- a/qbraid_qir/qasm3/__init__.py
+++ b/qbraid_qir/qasm3/__init__.py
@@ -41,9 +41,16 @@ Exceptions
    Qasm3ConversionError
 
 """
+from .checker import semantic_check
 from .convert import qasm3_to_qir
 from .elements import Qasm3Module
 from .exceptions import Qasm3ConversionError
 from .visitor import BasicQasmVisitor
 
-__all__ = ["qasm3_to_qir", "Qasm3Module", "Qasm3ConversionError", "BasicQasmVisitor"]
+__all__ = [
+    "semantic_check",
+    "qasm3_to_qir",
+    "Qasm3Module",
+    "Qasm3ConversionError",
+    "BasicQasmVisitor",
+]

--- a/qbraid_qir/qasm3/checker.py
+++ b/qbraid_qir/qasm3/checker.py
@@ -26,7 +26,7 @@ def semantic_check(
     program: Union[openqasm3.ast.Program, str],
     name: Optional[str] = None,
     **kwargs,
-) -> tuple[bool, Optional[Exception]]:
+) -> None:
     """Validates a given OpenQASM 3 program for semantic correctness.
 
     Args:
@@ -39,11 +39,11 @@ def semantic_check(
         record_output (bool): Whether to record output calls for registers, default `True`
 
     Returns:
-        bool : True if the program is semantically correct, False otherwise.
-        err : The exception that caused the program to be semantically incorrect.
+        Optional[Exception]: None if the program is semantically correct, otherwise an exception.
 
     Raises:
         Exception: If the input is not a valid OpenQASM 3 program.
+        Qasm3ConversionError: If the program is semantically incorrect.
     """
     if isinstance(program, str):
         program = openqasm3.parse(program)
@@ -61,6 +61,4 @@ def semantic_check(
         visitor = BasicQasmVisitor(check_only=True, **kwargs)
         module.accept(visitor)
     except (Qasm3ConversionError, TypeError, ValueError) as err:
-        return (False, err)
-
-    return (True, None)
+        raise err

--- a/qbraid_qir/qasm3/checker.py
+++ b/qbraid_qir/qasm3/checker.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2024 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Module containing OpenQASM semantic checker function
+
+"""
+from typing import Optional, Union
+
+import openqasm3
+from pyqir import Context, qir_module
+
+from .elements import Qasm3Module, generate_module_id
+from .exceptions import Qasm3ConversionError
+from .visitor import BasicQasmVisitor
+
+
+def semantic_check(
+    program: Union[openqasm3.ast.Program, str],
+    name: Optional[str] = None,
+    **kwargs,
+) -> tuple[bool, Optional[Exception]]:
+    """Validates a given OpenQASM 3 program for semantic correctness.
+
+    Args:
+        program (openqasm3.ast.Program or str): The OpenQASM 3 program to convert.
+        name (str, optional): Identifier for created QIR module. Auto-generated if not provided.
+
+    Keyword Args:
+        initialize_runtime (bool): Whether to perform quantum runtime environment initialization,
+                                   default `True`.
+        record_output (bool): Whether to record output calls for registers, default `True`
+
+    Returns:
+        bool : True if the program is semantically correct, False otherwise.
+        err : The exception that caused the program to be semantically incorrect.
+
+    Raises:
+        Exception: If the input is not a valid OpenQASM 3 program.
+    """
+    if isinstance(program, str):
+        program = openqasm3.parse(program)
+
+    elif not isinstance(program, openqasm3.ast.Program):
+        raise TypeError("Input quantum program must be of type openqasm3.ast.Program or str.")
+
+    if name is None:
+        name = generate_module_id()
+
+    llvm_module = qir_module(Context(), name)
+    module = Qasm3Module.from_program(program, llvm_module)
+
+    try:
+        visitor = BasicQasmVisitor(check_only=True, **kwargs)
+        module.accept(visitor)
+    except (Qasm3ConversionError, TypeError, ValueError) as err:
+        return (False, err)
+
+    return (True, None)

--- a/tests/qasm3_qir/test_checker.py
+++ b/tests/qasm3_qir/test_checker.py
@@ -20,32 +20,28 @@ from qbraid_qir.qasm3.exceptions import Qasm3ConversionError
 
 
 def test_correct_check():
-    check, err = semantic_check("OPENQASM 3; include 'stdgates.inc'; qubit q;")
-    assert check
-    assert err is None
+    assert semantic_check("OPENQASM 3; include 'stdgates.inc'; qubit q;") is None
 
 
 def test_incorrect_check():
-    check, err = semantic_check(
-        """
-        //semantically incorrect program
-        OPENQASM 3;
-        include 'stdgates.inc';
-        qubit q;
-        for int[32] i in [0:10] {
-           h q;
-        }
-        rx(3.14) q[2];
-        """,
-        name="test",
-    )
-    assert not check
-    assert err is not None
-    assert isinstance(err, Qasm3ConversionError)
+    with pytest.raises(Qasm3ConversionError):
+        semantic_check(
+            """
+            //semantically incorrect program
+            OPENQASM 3;
+            include 'stdgates.inc';
+            qubit q;
+            for int[32] i in [0:10] {
+            h q;
+            }
+            rx(3.14) q[2];
+            """,
+            name="test",
+        )
 
 
 def test_incorrect_program_type():
     with pytest.raises(
         TypeError, match="Input quantum program must be of type openqasm3.ast.Program or str."
     ):
-        _, _ = semantic_check(1234)
+        semantic_check(1234)

--- a/tests/qasm3_qir/test_checker.py
+++ b/tests/qasm3_qir/test_checker.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2023 qBraid
+#
+# This file is part of the qBraid-SDK
+#
+# The qBraid-SDK is free software released under the GNU General Public License v3
+# or later. You can redistribute and/or modify it under the terms of the GPL v3.
+# See the LICENSE file in the project root or <https://www.gnu.org/licenses/gpl-3.0.html>.
+#
+# THERE IS NO WARRANTY for the qBraid-SDK, as per Section 15 of the GPL v3.
+
+"""
+Tests the checker module of qasm3
+
+"""
+
+import pytest
+
+from qbraid_qir.qasm3.checker import semantic_check
+from qbraid_qir.qasm3.exceptions import Qasm3ConversionError
+
+
+def test_correct_check():
+    check, err = semantic_check("OPENQASM 3; include 'stdgates.inc'; qubit q;")
+    assert check
+    assert err is None
+
+
+def test_incorrect_check():
+    check, err = semantic_check(
+        """
+        //semantically incorrect program
+        OPENQASM 3;
+        include 'stdgates.inc';
+        qubit q;
+        for int[32] i in [0:10] {
+           h q;
+        }
+        rx(3.14) q[2];
+        """,
+        name="test",
+    )
+    assert not check
+    assert err is not None
+    assert isinstance(err, Qasm3ConversionError)
+
+
+def test_incorrect_program_type():
+    with pytest.raises(
+        TypeError, match="Input quantum program must be of type openqasm3.ast.Program or str."
+    ):
+        _, _ = semantic_check(1234)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
Fixes #147 

- Add a `checker.py` for evaluating qasm3 programs for semantic validity. 
- While this is still bounded by the QIR constructs, it would be nice to have complete semantic check facility. Eg. right now the `if` block is only conditioned on single `bit` values as QIR does not have support for arbitrary branching statements.  
- Once the analyser is decoupled from the pyqir bindings (post #148), we can extend this further to capture full semantics