### PR TITLE
Restructure error handling for semantics

### DIFF
--- a/qbraid_qir/qasm3/checker.py
+++ b/qbraid_qir/qasm3/checker.py
@@ -60,5 +60,7 @@ def semantic_check(
     try:
         visitor = BasicQasmVisitor(check_only=True, **kwargs)
         module.accept(visitor)
+        visitor.finalize_check()
+
     except (Qasm3ConversionError, TypeError, ValueError) as err:
         raise err

--- a/qbraid_qir/qasm3/convert.py
+++ b/qbraid_qir/qasm3/convert.py
@@ -59,6 +59,7 @@ def qasm3_to_qir(
 
     visitor = BasicQasmVisitor(**kwargs)
     module.accept(visitor)
+    visitor.finalize_check()
 
     err = llvm_module.verify()
     if err is not None:

--- a/qbraid_qir/qasm3/elements.py
+++ b/qbraid_qir/qasm3/elements.py
@@ -83,6 +83,7 @@ class Variable:
         self.value = value
         self.is_constant = is_constant
         self.readonly = readonly
+        self.referenced = False
 
 
 class _ProgramElement(metaclass=ABCMeta):

--- a/qbraid_qir/qasm3/exceptions.py
+++ b/qbraid_qir/qasm3/exceptions.py
@@ -13,11 +13,23 @@ Module defining exceptions for errors raised during QASM3 conversions.
 
 """
 import logging
+from enum import Enum
 from typing import Optional, Type
 
 from openqasm3.ast import Span
 
 from qbraid_qir.exceptions import QirConversionError
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s - %(message)s")
+
+
+class WarnType(Enum):
+    """Enum for different qasm3 semantic warnings."""
+
+    UNUSED_VAR = "unused"
+    IMPLICIT_CAST = "implicit_cast"
+    UNUSED_FUNCTION = "unused_function"
+    UNUSED_GATE = "unused_gate"
 
 
 class Qasm3ConversionError(QirConversionError):
@@ -49,3 +61,30 @@ def raise_qasm3_error(
     if raised_from:
         raise err_type(message) from raised_from
     raise err_type(message)
+
+
+def emit_qasm3_warning(
+    warning_type: WarnType,
+    message: Optional[str] = None,
+    span: Optional[Span] = None,
+):
+    """Emits a QASM3 conversion warning.
+
+    Args:
+        warning_type: The type of warning.
+        message: The warning message.
+        span: The span (location) in the QASM file where the warning occurred.
+
+    Returns:
+        None
+    """
+    err_message = "No message provided."
+    if span:
+        err_message = (
+            f"Warning at line {span.start_line}, column {span.start_column} in QASM file. "
+        )
+
+    if message:
+        err_message = message if not span else f"{err_message} {message}"
+
+    logging.warning(f"{warning_type} warning emitted: {err_message}")

--- a/qbraid_qir/qasm3/expressions.py
+++ b/qbraid_qir/qasm3/expressions.py
@@ -132,17 +132,13 @@ class Qasm3ExprEvaluator:
         Returns:
             var_value: The value of the variable.
         """
-
         var_value = None
+        variable_obj = cls.visitor_obj._get_from_visible_scope(var_name)
         if isinstance(expression, Identifier):
-            var_value = cls.visitor_obj._get_from_visible_scope(var_name).value
+            var_value = variable_obj.value
         else:
-            validated_indices = Qasm3Analyzer.analyze_classical_indices(
-                indices, cls.visitor_obj._get_from_visible_scope(var_name)
-            )
-            var_value = Qasm3Analyzer.find_array_element(
-                cls.visitor_obj._get_from_visible_scope(var_name).value, validated_indices
-            )
+            validated_indices = Qasm3Analyzer.analyze_classical_indices(indices, variable_obj)
+            var_value = Qasm3Analyzer.find_array_element(variable_obj.value, validated_indices)
         return var_value
 
     @classmethod


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
Fixes #149 

- We want to have a better way to emit errors to the user when doing semantic analysis. Currently we stop processing after an error is encountered, which may not be the best strategy for error discovery
- Tasks - 
    - [ ] Define warning and fatal errors 
    - [ ] Strategy for warnings 
    - [ ] Strategy for fatal errors
    - [ ] Error threshold 
    - [ ] Tests 
