### PR TITLE
Support for externally linked gates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ Discord = "https://discord.gg/TPBU2sa8Et"
 
 [project.optional-dependencies]
 cirq = ["cirq-core>=1.3.0,<1.5.0"]
-qasm3 = ["pyqasm==0.0.3", "numpy"]
+qasm3 = ["pyqasm==0.1.0a1", "numpy"]
 test = ["qbraid>=0.8.3,<0.9.0", "pytest", "pytest-cov", "autoqasm>=0.1.0"]
 lint = ["black", "isort", "pylint", "qbraid-cli>=0.8.7"]
 docs = ["sphinx>=7.3.7,<=8.3.0", "sphinx-autodoc-typehints>=1.24,<2.6", "sphinx-rtd-theme>=2.0,<3.1", "docutils<0.22", "sphinx-copybutton"]

--- a/qbraid_qir/qasm3/convert.py
+++ b/qbraid_qir/qasm3/convert.py
@@ -54,7 +54,7 @@ def qasm3_to_qir(
 
     external_gates: list[str] = kwargs.get("external_gates", [])
 
-    qasm3_module = pyqasm.load(program)
+    qasm3_module = pyqasm.loads(program)
     qasm3_module.unroll(external_gates=external_gates)
     if name is None:
         name = generate_module_id()

--- a/qbraid_qir/qasm3/convert.py
+++ b/qbraid_qir/qasm3/convert.py
@@ -51,10 +51,10 @@ def qasm3_to_qir(
 
     elif not isinstance(program, str):
         raise TypeError("Input quantum program must be of type openqasm3.ast.Program or str.")
-    
+
     external_gates: list[str] = kwargs.get("external_gates", [])
 
-    #qasm3_module = pyqasm.unroll(program, as_module=True)
+    # qasm3_module = pyqasm.unroll(program, as_module=True)
     qasm3_module = pyqasm.pyqasm.load(program)
     qasm3_module.unroll(external_gates=external_gates)
     if name is None:

--- a/qbraid_qir/qasm3/convert.py
+++ b/qbraid_qir/qasm3/convert.py
@@ -51,8 +51,12 @@ def qasm3_to_qir(
 
     elif not isinstance(program, str):
         raise TypeError("Input quantum program must be of type openqasm3.ast.Program or str.")
+    
+    external_gates: list[str] = kwargs.get("external_gates", [])
 
-    qasm3_module = pyqasm.unroll(program, as_module=True)
+    #qasm3_module = pyqasm.unroll(program, as_module=True)
+    qasm3_module = pyqasm.pyqasm.load(program)
+    qasm3_module.unroll(external_gates=external_gates)
     if name is None:
         name = generate_module_id()
     llvm_module = qir_module(Context(), name)

--- a/qbraid_qir/qasm3/convert.py
+++ b/qbraid_qir/qasm3/convert.py
@@ -54,7 +54,7 @@ def qasm3_to_qir(
 
     external_gates: list[str] = kwargs.get("external_gates", [])
 
-    qasm3_module = pyqasm.pyqasm.load(program)
+    qasm3_module = pyqasm.load(program)
     qasm3_module.unroll(external_gates=external_gates)
     if name is None:
         name = generate_module_id()

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -374,7 +374,7 @@ class QasmQIRVisitor:
             op_parameters = self._get_op_parameters(operation)
 
         if op_parameters is not None:
-            # qir_func(self._builder, *op_parameters, *op_qubits)
+           
             self._builder.call(qir_function, [*op_parameters, *op_qubits])
         else:
             self._builder.call(qir_function, op_qubits)

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -482,7 +482,7 @@ class QasmQIRVisitor:
             qasm3_ast.QuantumBarrier: self._visit_barrier,
             qasm3_ast.QuantumGate: self._visit_generic_gate_operation,
             qasm3_ast.BranchingStatement: self._visit_branching_statement,
-            qasm3_ast.QuantumPhase: lambda x: None  # No operation
+            qasm3_ast.QuantumPhase: lambda x: None,  # No operation
         }
 
         visitor_function = visit_map.get(type(statement))

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -482,6 +482,7 @@ class QasmQIRVisitor:
             qasm3_ast.QuantumBarrier: self._visit_barrier,
             qasm3_ast.QuantumGate: self._visit_generic_gate_operation,
             qasm3_ast.BranchingStatement: self._visit_branching_statement,
+            qasm3_ast.QuantumPhase: lambda x: None  # No operation
         }
 
         visitor_function = visit_map.get(type(statement))

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -343,10 +343,16 @@ class QasmQIRVisitor:
         op_qubits = self._get_op_bits(operation)
         op_qubit_count = len(op_qubits)
 
+        if len(operation.modifiers) > 0:
+            raise_qasm3_error(
+                "Modifiers on externally linked gates are not supported in pyqir",
+                err_type=NotImplementedError,
+            )
+
         context = self._llvm_module.context
         if self._external_gates_map[op_name] is None:
             # First time seeing this external gate -> define new function
-            qir_function_arguments = [pyqir.Type.double(context)]*len(operation.arguments) +  [pyqir.qubit_type(context)]*op_qubit_count
+            qir_function_arguments = [pyqir.Type.double(context)]*len(operation.arguments) + [pyqir.qubit_type(context)]*op_qubit_count
             qir_function = pyqir.Function(pyqir.FunctionType(pyqir.Type.void(context), 
                                                              qir_function_arguments), 
                                                              pyqir.Linkage.EXTERNAL, 

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -355,7 +355,8 @@ class QasmQIRVisitor:
             )
 
         context = self._llvm_module.context
-        if self._external_gates_map[op_name] is None:
+        qir_function = self._external_gates_map[op_name]
+        if qir_function is None:
             # First time seeing this external gate -> define new function
             qir_function_arguments = [pyqir.Type.double(context)] * len(operation.arguments)
             qir_function_arguments += [pyqir.qubit_type(context)] * op_qubit_count
@@ -367,8 +368,6 @@ class QasmQIRVisitor:
                 self._llvm_module,
             )
             self._external_gates_map[op_name] = qir_function
-        else:
-            qir_function = self._external_gates_map[op_name]
 
         op_parameters = None
         if len(operation.arguments) > 0:  # parametric gate

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -374,7 +374,6 @@ class QasmQIRVisitor:
             op_parameters = self._get_op_parameters(operation)
 
         if op_parameters is not None:
-           
             self._builder.call(qir_function, [*op_parameters, *op_qubits])
         else:
             self._builder.call(qir_function, op_qubits)

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -38,6 +38,9 @@ class QasmQIRVisitor:
     Args:
         initialize_runtime (bool): If True, quantum runtime will be initialized. Defaults to True.
         record_output (bool): If True, output of the circuit will be recorded. Defaults to True.
+        external_gates (list[str]): List of custom gates that should not be unrolled into their definition. 
+                                    Instead, these gates are marked for external linkage, as qir-functions
+                                    with the name "__quantum__qis__<GateName>__body(...)"
     """
 
     def __init__(

--- a/tests/cirq_qir/test_cirq_to_qir.py
+++ b/tests/cirq_qir/test_cirq_to_qir.py
@@ -143,7 +143,7 @@ def test_triple_qubit_gates(circuit_name, request):
     check_attributes(generated_qir, 3, 3)
     func = get_entry_point_body(generated_qir)
     assert func[0] == initialize_call_string()
-    assert func[1] == generic_op_call_string(qir_op, [0, 1, 2])
+    assert func[1] == generic_op_call_string(qir_op, [], [0, 1, 2])
     assert func[5] == return_string()
     assert len(func) == 6
 

--- a/tests/qasm3_qir/converter/test_gates.py
+++ b/tests/qasm3_qir/converter/test_gates.py
@@ -25,6 +25,8 @@ from tests.qasm3_qir.fixtures.gates import (
 from tests.qir_utils import (
     check_attributes,
     check_custom_qasm_gate_op,
+    check_custom_qasm_gate_op_with_external_gates,
+    check_generic_gate_op,
     check_single_qubit_gate_op,
     check_single_qubit_rotation_op,
     check_three_qubit_gate_op,
@@ -144,6 +146,20 @@ def test_qasm_u3_gates():
     check_single_qubit_rotation_op(generated_qir, 1, [0], [0.5, 0.5, 0.5], "u3")
 
 
+def test_qasm_u3_gates_external():
+    qasm3_string = """
+    OPENQASM 3;
+    include "stdgates.inc";
+
+    qubit[2] q1;
+    u3(0.5, 0.5, 0.5) q1[0];
+    """
+    result = qasm3_to_qir(qasm3_string, external_gates=["u3"])
+    generated_qir = str(result).splitlines()
+    check_attributes(generated_qir, 2, 0)
+    check_generic_gate_op(generated_qir, 1, [0], ["5.000000e-01"] * 3, "u3")
+
+
 def test_qasm_u2_gates():
     qasm3_string = """
     OPENQASM 3;
@@ -169,6 +185,19 @@ def test_custom_ops(test_name, request):
 
     # Check for custom gate definition
     check_custom_qasm_gate_op(generated_qir, gate_type)
+
+
+@pytest.mark.parametrize("test_name", custom_op_tests)
+def test_custom_ops_with_external_gates(test_name, request):
+    qasm3_string = request.getfixturevalue(test_name)
+    gate_type = test_name.removeprefix("Fixture_")
+    result = qasm3_to_qir(qasm3_string, external_gates=["custom", "custom1"])
+
+    generated_qir = str(result).splitlines()
+    check_attributes(generated_qir, 2, 0)
+
+    # Check for custom gate definition
+    check_custom_qasm_gate_op_with_external_gates(generated_qir, gate_type)
 
 
 def test_pow_gate_modifier():

--- a/tests/qir_utils.py
+++ b/tests/qir_utils.py
@@ -463,7 +463,6 @@ def check_custom_qasm_gate_op_with_external_gates(qir: list[str], test_type: str
         )
     elif test_type == "complex":
         # Only custom1 is external, custom2 and custom3 should be unrolled
-        print(qir)
         check_generic_gate_op(qir, 1, [0], [], "custom1")
         check_generic_gate_op(qir, 1, [0], ["1.000000e-01"], "ry")
         check_generic_gate_op(qir, 1, [0], ["2.000000e-01"], "rz")

--- a/tests/qir_utils.py
+++ b/tests/qir_utils.py
@@ -103,9 +103,11 @@ def reset_call_string(qb: int) -> str:
     return f"call void @__quantum__qis__reset__body({_qubit_string(qb)})"
 
 
-def generic_op_call_string(name: str, qbs: list[int]) -> str:
-    args = ", ".join(_qubit_string(qb) for qb in qbs)
-    return f"call void @__quantum__qis__{name}__body({args})"
+def generic_op_call_string(name: str, angles: list[str], qubits: list[int]) -> str:
+    angles = ["double " + angle for angle in angles]
+    qubits = [_qubit_string(q) for q in qubits]
+    parameters = ", ".join(angles + qubits)
+    return f"call void @__quantum__qis__{name}__body({parameters})"
 
 
 def return_string() -> str:
@@ -235,6 +237,31 @@ def check_single_qubit_gate_op(
         ), f"Incorrect single qubit gate count: {expected_ops} expected, {op_count} actual"
 
 
+def check_generic_gate_op(
+    qir: list[str], expected_ops: int, qubit_list: list[int], param_list: list[str], gate_name: str
+):
+    entry_body = get_entry_point_body(qir)
+    op_count = 0
+
+    for line in entry_body:
+        gate_call_id = (
+            f"qis__{gate_name}" if "dg" not in gate_name else f"qis__{gate_name.removesuffix('dg')}"
+        )
+        if line.strip().startswith("call") and gate_call_id in line:
+            expected_line = generic_op_call_string(gate_name, param_list, qubit_list)
+            assert line.strip() == expected_line, (
+                "Incorrect single qubit gate call in qir"
+                + f"Expected {expected_line}, found {line.strip()}"
+            )
+            op_count += 1
+
+        if op_count == expected_ops:
+            break
+
+    if op_count != expected_ops:
+        assert False, f"Incorrect gate count: {expected_ops} expected, {op_count} actual"
+
+
 def check_two_qubit_gate_op(
     qir: list[str], expected_ops: int, qubit_lists: list[int], gate_name: str
 ):
@@ -346,7 +373,7 @@ def check_three_qubit_gate_op(
     for line in entry_body:
         if line.strip().startswith("call") and f"qis__{gate_name}" in line:
             assert line.strip() == generic_op_call_string(
-                gate_name, qubit_lists[q_id]
+                gate_name, [], qubit_lists[q_id]
             ), f"Incorrect three qubit gate call in qir - {line}"
             op_count += 1
             q_id += 1
@@ -423,6 +450,24 @@ def check_custom_qasm_gate_op(qir: list[str], test_type: str):
         _validate_nested_custom_op(entry_body)
     elif test_type == "complex":
         _validate_complex_custom_op(entry_body)
+    else:
+        assert False, f"Unknown test type {test_type} for custom ops"
+
+
+def check_custom_qasm_gate_op_with_external_gates(qir: list[str], test_type: str):
+    if test_type == "simple":
+        check_generic_gate_op(qir, 1, [0, 1], ["1.100000e+00"], "custom")
+    elif test_type == "nested":
+        check_generic_gate_op(
+            qir, 1, [0, 1], ["4.800000e+00", "1.000000e-01", "3.000000e-01"], "custom"
+        )
+    elif test_type == "complex":
+        # Only custom1 is external, custom2 and custom3 should be unrolled
+        print(qir)
+        check_generic_gate_op(qir, 1, [0], [], "custom1")
+        check_generic_gate_op(qir, 1, [0], ["1.000000e-01"], "ry")
+        check_generic_gate_op(qir, 1, [0], ["2.000000e-01"], "rz")
+        check_generic_gate_op(qir, 1, [0, 1], [], "cnot")
     else:
         assert False, f"Unknown test type {test_type} for custom ops"
 


### PR DESCRIPTION
This is the companion PR to https://github.com/qBraid/pyqasm/pull/59 for externally linked gates, as suggested here https://github.com/qBraid/qbraid-qir/issues/167.

This is probably not ready to merge, but I figured it's easier if I get some feedback first.  With both changes, external gates work in qbraid-qir, at least for my use-case.

If both PRs are merged, one can call e.g. `qasm3_to_qir(qasm_str, external_gates=["mygate"])`.

Then `pyqasm` does not unroll "mygate", but leaves it as a node in the AST. `qbraid-qir` then takes this node and converts it to an externally linked qir function. There are serveral ways this could be done (@christian512 originally suggested that the user passes a `pyqir.Function` that the external gate should be mapped to, alternatively the user could potentially also just pass the name of the desired qir function that the gate should be mapped to). Instead for now I chose to create the new qir function dynamically based on the arguments of the original gate and with the fixed name `__quantum__qis__<GateName>__body`, but this strategy could of course still be changed.

With `qasm3_to_qir(qasm_str, external_gates=["mygate"])`, the following QASM would then be mapped to the IR below:

```qasm
OPENQASM 3.0;
include "stdgates.inc";
gate mygate(p0) _gate_q_0, _gate_q_1 {
  h _gate_q_1;
  cx _gate_q_0, _gate_q_1;
  rz(p0) _gate_q_1;
  cx _gate_q_0, _gate_q_1;
  h _gate_q_1;
}
bit[2] c;
qubit[2] q;
ry(pi/2) q[0];
mygate(pi/2) q[0], q[1];
```

```ir
entry:
  call void @__quantum__rt__initialize(i8* null)
  call void @__quantum__qis__ry__body(double 0x3FF921FB54442D18, %Qubit* null)
  call void @__quantum__qis__mygate__body(double 0x3FF921FB54442D18, %Qubit* null, %Qubit* inttoptr (i64 1 to %Qubit*))
  call void @__quantum__rt__result_record_output(%Result* null, i8* null)
  call void @__quantum__rt__result_record_output(%Result* inttoptr (i64 1 to %Result*), i8* null)
  ret void
```

The original `_visit_basic_gate_operation` had some logic where the gate was applied to multiple subsets of qubits 
```python
for i in range(0, len(op_qubits), op_qubit_count):
    # we apply the gate on the qubit subset linearly
    qubit_subset = op_qubits[i : i + op_qubit_count]
    ...
```
which I did not replicate in `_visit_external_gate_operation` since I did not understand this logic and could not trigger its execution. This might be be something that still requires change.

I also did not yet write any tests because most of the existing tests where failing due to import errors of `pyqasm.pyqasm` (I assume you are currently in the process of changing how pyqasm gets imported?). If the rest of this PR is good, I can look into this again and add tests for the external gates.

Closes https://github.com/qBraid/qbraid-qir/issues/167