### PR TITLE
Update `pyqasm` and `qbraid` dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,5 +29,6 @@ Types of changes:
 
 ### ⬇️  Dependency Updates 
 - Added `pyqasm` as project dependency ([#173](https://github.com/qBraid/qbraid-qir/pull/173))
+- Updated `pyqasm` and `qbraid` dependencies ([#183](https://github.com/qBraid/qbraid-qir/pull/183))
 
 ### 👋  Deprecations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ Discord = "https://discord.gg/TPBU2sa8Et"
 
 [project.optional-dependencies]
 cirq = ["cirq-core>=1.3.0,<1.5.0"]
-qasm3 = ["pyqasm==0.0.2", "numpy"]
-test = ["qbraid>=0.7.1,<0.9.0", "pytest", "pytest-cov", "autoqasm>=0.1.0"]
+qasm3 = ["pyqasm==0.0.3", "numpy"]
+test = ["qbraid>=0.8.3,<0.9.0", "pytest", "pytest-cov", "autoqasm>=0.1.0"]
 lint = ["black", "isort", "pylint", "qbraid-cli>=0.8.7"]
 docs = ["sphinx>=7.3.7,<=8.3.0", "sphinx-autodoc-typehints>=1.24,<2.6", "sphinx-rtd-theme>=2.0,<3.1", "docutils<0.22", "sphinx-copybutton"]
 

--- a/qbraid_qir/qasm3/convert.py
+++ b/qbraid_qir/qasm3/convert.py
@@ -52,7 +52,9 @@ def qasm3_to_qir(
     elif not isinstance(program, str):
         raise TypeError("Input quantum program must be of type openqasm3.ast.Program or str.")
 
-    qasm3_module = pyqasm.unroll(program, as_module=True)
+    qasm3_module = pyqasm.load(program)
+    qasm3_module.unroll()
+
     if name is None:
         name = generate_module_id()
     llvm_module = qir_module(Context(), name)

--- a/tests/qasm3_qir/autoqasm/test_convert.py
+++ b/tests/qasm3_qir/autoqasm/test_convert.py
@@ -20,7 +20,7 @@ import autoqasm.instructions as ins
 import numpy as np
 import pytest
 from pyqir import Module
-from qbraid.passes.qasm3.compat import add_stdgates_include, insert_gate_def
+from qbraid.passes.qasm.compat import add_stdgates_include, insert_gate_def
 
 from qbraid_qir.qasm3 import qasm3_to_qir
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes

Dependency updates:
* Updated `pyqasm` version to `0.0.3` and `qbraid` version to `>=0.8.3,<0.9.0` in `pyproject.toml`.

Function modifications:
* Changed the `qasm3_to_qir` function to use `pyqasm.load` and added a call to `unroll` on the loaded module in `qbraid_qir/qasm3/convert.py`.

Import statement fix:
* Corrected the import path for `add_stdgates_include` and `insert_gate_def` in `tests/qasm3_qir/autoqasm/test_convert.py`.