### PR TITLE
Fix type error for integer arg in external gate call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Types of changes:
 - Changed project from GPL to Apache 2.0 license ([#198](https://github.com/qBraid/qbraid-qir/pull/198))
 
 ### 🐛  Bug Fixes
+- Fix type error for integer in external gate call argument ([#202](https://github.com/qBraid/qbraid-qir/pull/202))
 
 ### ⬇️  Dependency Updates 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Discord = "https://discord.gg/TPBU2sa8Et"
 [project.optional-dependencies]
 cirq = ["cirq-core>=1.3.0,<1.5.0"]
 qasm3 = ["pyqasm>=0.1.0,<0.2.0", "numpy"]
-test = ["qbraid>=0.8.3,<0.10.0", "pytest", "pytest-cov", "autoqasm>=0.1.0"]
+test = ["qbraid>=0.9.0,<0.10.0", "pytest", "pytest-cov", "autoqasm>=0.1.0"]
 lint = ["black", "isort", "pylint", "qbraid-cli>=0.10.1"]
 docs = ["sphinx>=7.3.7,<=8.3.0", "sphinx-autodoc-typehints>=1.24,<3.1", "sphinx-rtd-theme>=2.0,<3.1", "docutils<0.22", "sphinx-copybutton"]
 

--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -376,7 +376,7 @@ class QasmQIRVisitor:
         op_parameters = None
         if len(operation.arguments) > 0:  # parametric gate
             op_parameters = self._get_op_parameters(operation)
-
+            op_parameters = list(map(float, op_parameters))
         if op_parameters is not None:
             self._builder.call(qir_function, [*op_parameters, *op_qubits])
         else:

--- a/tests/qasm3_qir/converter/test_gates.py
+++ b/tests/qasm3_qir/converter/test_gates.py
@@ -157,11 +157,13 @@ def test_qasm_u3_gates_external():
 
     qubit[2] q1;
     u3(0.5, 0.5, 0.5) q1[0];
+    rz(1) q1[1];
     """
-    result = qasm3_to_qir(qasm3_string, external_gates=["u3"])
+    result = qasm3_to_qir(qasm3_string, external_gates=["u3", "rz"])
     generated_qir = str(result).splitlines()
     check_attributes(generated_qir, 2, 0)
     check_generic_gate_op(generated_qir, 1, [0], ["5.000000e-01"] * 3, "u3")
+    check_single_qubit_rotation_op(generated_qir, 1, [1], [1.0], "rz")
 
 
 def test_qasm_u2_gates():


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Fixes #201 

## Summary of changes
- Due to type casting rules in `pyqir`, integers were not accepted as valid function call args. Added conversion to float before calling the function for external gates 
- Also updated the qbraid dependency to >=0.9.0