### PR TITLE
Add `i64` type in external gate arguments

### DIFF
--- a/tests/qasm3_qir/converter/test_gates.py
+++ b/tests/qasm3_qir/converter/test_gates.py
@@ -163,7 +163,7 @@ def test_qasm_u3_gates_external():
     generated_qir = str(result).splitlines()
     check_attributes(generated_qir, 2, 0)
     check_generic_gate_op(generated_qir, 1, [0], ["5.000000e-01"] * 3, "u3")
-    check_single_qubit_rotation_op(generated_qir, 1, [1], [1.0], "rz")
+    check_single_qubit_rotation_op(generated_qir, 1, [1], [1], "rz")
 
 
 def test_qasm_u2_gates():

--- a/tests/qir_utils.py
+++ b/tests/qir_utils.py
@@ -83,12 +83,13 @@ def double_op_call_string(name: str, qb1: int, qb2: int) -> str:
     return f"call void @__quantum__qis__{name}__body({_qubit_string(qb1)}, {_qubit_string(qb2)})"
 
 
-def rotation_call_string(name: str, theta: Union[float, str], qb: int) -> str:
-    if isinstance(theta, str):
+def rotation_call_string(name: str, theta: Union[float, str], qb: int, param_type="double") -> str:
+    if isinstance(theta, str) or param_type == "i64":
         # for hex matching
-        theta = theta.replace("X", "x")
-        return f"call void @__quantum__qis__{name}__body(double {theta}, {_qubit_string(qb)})"
-    return f"call void @__quantum__qis__{name}__body(double {theta:#e}, {_qubit_string(qb)})"
+        if isinstance(theta, str):
+            theta = theta.replace("X", "x")
+        return f"call void @__quantum__qis__{name}__body({param_type} {theta}, {_qubit_string(qb)})"
+    return f"call void @__quantum__qis__{name}__body({param_type} {theta:#e}, {_qubit_string(qb)})"
 
 
 def measure_call_string(name: str, res: str, qb: int) -> str:
@@ -354,8 +355,9 @@ def check_single_qubit_rotation_op(
         return
     for line in entry_body:
         if line.strip().startswith("call") and f"qis__{gate_name}" in line:
+            param_type = "double" if "double" in line else "i64"
             assert line.strip() == rotation_call_string(
-                gate_name, param_list[q_id], qubit_list[q_id]
+                gate_name, param_list[q_id], qubit_list[q_id], param_type
             ), f"Incorrect rotation gate call in qir - {line}"
             op_count += 1
             q_id += 1


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->
Follow up for #201 

## Summary of changes
- By default, all args in external gates were considered as `double` which resulted in discrepancy in the function call by `pyqir`
- Adds the `i64` type in the external gate arguments to account for `int` arguments