### PR TITLE
Bump version to `v0.3.1`, add changelog and add modifiers test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Types of changes:
 ## [Unreleased]
 
 ### ➕  New Features 
+- `ctrl` and `negctrl` modifier support added with pyqasm>=0.2.1 ([#204](https://github.com/qBraid/qbraid-qir/pull/204))
 
 ### 🌟  Improvements
 
@@ -25,5 +26,7 @@ Types of changes:
 - Fix type error for integer in external gate call argument ([#202](https://github.com/qBraid/qbraid-qir/pull/202))
 
 ### ⬇️  Dependency Updates 
+- Update sphinx-autodoc-typehints requirement from <2.6,>=1.24 to >=1.24,<3.1 ([#193](https://github.com/qBraid/qbraid-qir/pull/193))
+- Update pyqasm dependency from `"pyqasm>=0.1.0,<0.2.0"` to `"pyqasm>=0.2.1,<0.3.0"` ([#204](https://github.com/qBraid/qbraid-qir/pull/204))
 
 ### 👋  Deprecations

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,8 +22,8 @@ authors:
     family-names: Hill
     affiliation: qBraid Co.
 repository-code: 'https://github.com/qBraid/qbraid-qir'
-url: 'https://sdk.qbraid.com/projects/qir/en/v0.3.0/'
-repository-artifact: 'https://github.com/qBraid/qbraid-qir/releases/tag/v0.3.0'
+url: 'https://sdk.qbraid.com/projects/qir/en/v0.3.1/'
+repository-artifact: 'https://github.com/qBraid/qbraid-qir/releases/tag/v0.3.1'
 keywords:
   - python
   - quantum-computing
@@ -32,5 +32,5 @@ keywords:
   - cirq
   - openasm
 license: Apache-2.0
-version: 0.3.0
-date-released: '2024-09-27'
+version: 0.3.1
+date-released: '2025-03-03'

--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ The BibTeX entry below is aligned with the latest stable release. For the most u
 citation details, please refer to [CITATION.cff](CITATION.cff).
 
 ```bibtex
-@software{Gupta_qBraid-QIR_Python_package_2024,
+@software{Gupta_qBraid-QIR_Python_package_2025,
   author = {Gupta, Harshit and Jain, Rohan and Kushnir, Samuel and Parakh, Priyansh and Hill, Ryan James},
-  license = {GPL-3.0},
+  license = {Apache-2.0},
   month = aug,
   title = {{qBraid-QIR: Python package for QIR conversions, integrations, and utilities.}},
   url = {https://github.com/qBraid/qbraid-qir},
-  version = {0.3.0},
-  year = {2024}
+  version = {0.3.1},
+  year = {2025}
 }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ Discord = "https://discord.gg/TPBU2sa8Et"
 
 [project.optional-dependencies]
 cirq = ["cirq-core>=1.3.0,<1.5.0"]
-qasm3 = ["pyqasm>=0.1.0,<0.2.0", "numpy"]
+qasm3 = ["pyqasm>=0.2.1,<0.3.0", "numpy"]
 test = ["qbraid>=0.9.0,<0.10.0", "pytest", "pytest-cov", "autoqasm>=0.1.0"]
 lint = ["black", "isort", "pylint", "qbraid-cli>=0.10.1"]
 docs = ["sphinx>=7.3.7,<=8.3.0", "sphinx-autodoc-typehints>=1.24,<3.1", "sphinx-rtd-theme>=2.0,<3.1", "docutils<0.22", "sphinx-copybutton"]

--- a/qbraid_qir/_version.py
+++ b/qbraid_qir/_version.py
@@ -18,4 +18,4 @@ Module containing version information
 Version number (major.minor.patch[-label])
 
 """
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/tests/qasm3_qir/converter/test_gates.py
+++ b/tests/qasm3_qir/converter/test_gates.py
@@ -269,18 +269,15 @@ def test_nested_gate_modifiers():
     check_single_qubit_gate_op(generated_qir, 2, [1, 1, 1], "z")
 
 
-def test_unsupported_modifiers():
-    # TO DO : add implementations, but till then we have tests
-    for modifier in ["ctrl", "negctrl"]:
-        with pytest.raises(
-            NotImplementedError,
-            match=r"Controlled modifier gates not yet supported .*",
-        ):
-            _ = qasm3_to_qir(
-                f"""
-                OPENQASM 3;
-                include "stdgates.inc";
-                qubit[2] q;
-                {modifier} @ h q[0], q[1];
-                """
-            )
+def test_ctrl_modifiers():
+    ctrl_modifiers = qasm3_to_qir(
+        f"""
+        OPENQASM 3;
+        include "stdgates.inc";
+        qubit[2] q;
+        ctrl @ x q[0], q[1];
+        """
+    )
+    generated_qir = str(ctrl_modifiers).splitlines()
+    check_attributes(generated_qir, 2, 0)
+    check_two_qubit_gate_op(generated_qir, 1, [[0, 1]], f"cx")

--- a/tests/qasm3_qir/converter/test_gates.py
+++ b/tests/qasm3_qir/converter/test_gates.py
@@ -271,7 +271,7 @@ def test_nested_gate_modifiers():
 
 def test_ctrl_modifiers():
     ctrl_modifiers = qasm3_to_qir(
-        f"""
+        """
         OPENQASM 3;
         include "stdgates.inc";
         qubit[2] q;
@@ -280,4 +280,4 @@ def test_ctrl_modifiers():
     )
     generated_qir = str(ctrl_modifiers).splitlines()
     check_attributes(generated_qir, 2, 0)
-    check_two_qubit_gate_op(generated_qir, 1, [[0, 1]], f"cx")
+    check_two_qubit_gate_op(generated_qir, 1, [[0, 1]], "cx")


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- https://github.com/qBraid/qbraid-qir/blob/main/CONTRIBUTING.md#pull-requests

⚠️ Your pull request title should be short, detailed, and understandable for all.
⚠️ Please link any issues that this PR aims to close, if applicable.
⚠️ If you believe this PR should be highlighted in the qBraid-QIR CHANGELOG, please add a new entry to the `CHANGELOG.md` file, summarizing the change, and including a link back to the PR.
-->

## Summary of changes
* Added support for `ctrl` and `negctrl` modifiers with `pyqasm>=0.2.1`.
* Updated `pyqasm` dependency from `"pyqasm>=0.1.0,<0.2.0"` to `"pyqasm>=0.2.1,<0.3.0"`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR29-R30) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L41-R41)
* Updated version `0.3.1` across multiple files
* Update `CHANGELOG.md`
