### PR TITLE
Fixed result_record_output

### DIFF
--- a/qbraid_qir/qasm3/visitor.py
+++ b/qbraid_qir/qasm3/visitor.py
@@ -106,7 +106,7 @@ class QasmQIRVisitor:
         if self._record_output is False:
             return
         i8p = pyqir.PointerType(pyqir.IntType(self._llvm_module.context, 8))
-        for i in range(module.qasm_program.num_qubits):
+        for i in range(module.qasm_program.num_clbits):         
             result_ref = pyqir.result(self._llvm_module.context, i)
             pyqir.rt.result_record_output(self._builder, result_ref, pyqir.Constant.null(i8p))
 


### PR DESCRIPTION
Ensure that the measurement results in the generated output align with the number of classical bits defined in the OpenQASM program.


## Summary of changes
In `qbraid_qir/qasm3/visitor.py` file, the `record_output` method has been updated to loop over `num_clbits` instead of `num_qubits`. Previously, when the number of classical bits was lower than the number of qubits, the generated QIR had an incorrect output configuration. 
Example Input: For the following OpenQASM program:
![image](https://github.com/user-attachments/assets/b9752cb5-4756-46ab-b4ce-75d37068ffb6)

Issue:
The generated output QIR incorrectly included two calls to `@__quantum__rt__result_record_output`, attempting to record a non-existent measurement result: 
![image](https://github.com/user-attachments/assets/e5bb2a33-f3f1-4186-b576-090ca1e82843)

By adjusting the loop to iterate over `num_clbits`, the generated QIR now correctly matches the number of classical bits, preventing unnecessary or erroneous result recordings.
