### PR TITLE
docs: add missing PR entries to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ Types of changes:
 
 ### ⬇️  Dependency Updates
 
+- Updated `autoqasm` requirement from `>=0.1.0` to `>=0.2.0` ([#278](https://github.com/qBraid/qbraid-qir/pull/278))
+- Updated `qbraid` requirement from `>=0.11.0,<0.12.0` to `>=0.11.1,<0.12.0` ([#279](https://github.com/qBraid/qbraid-qir/pull/279))
+- Updated `sphinx` requirement from `>=7.3.7,<=8.3.0` to `>=8.1.3,<=8.3.0` ([#282](https://github.com/qBraid/qbraid-qir/pull/282))
+- Updated `sphinx-rtd-theme` requirement from `>=2.0,<3.2` to `>=3.1.0,<3.2` ([#280](https://github.com/qBraid/qbraid-qir/pull/280))
+- Updated `sphinx-autodoc-typehints` requirement from `>=1.24,<3.2` to `>=3.0.1,<3.2` ([#281](https://github.com/qBraid/qbraid-qir/pull/281))
+- Bumped `actions/configure-pages` from 5 to 6 ([#274](https://github.com/qBraid/qbraid-qir/pull/274))
+- Bumped `actions/deploy-pages` from 4 to 5 ([#275](https://github.com/qBraid/qbraid-qir/pull/275))
+- Bumped `codecov/codecov-action` from 5.5.2 to 6.0.1 ([#276](https://github.com/qBraid/qbraid-qir/pull/276))
+
 ### 👋  Deprecations
 
 ## Past releases


### PR DESCRIPTION
## Summary

- Added 8 missing dependency update entries to the Unreleased section of the CHANGELOG for PRs merged after the v0.5.1 release (Feb 11, 2026)
- Python dependency updates: `autoqasm` (#278), `qbraid` (#279), `sphinx` (#282), `sphinx-rtd-theme` (#280), `sphinx-autodoc-typehints` (#281)
- GitHub Actions bumps: `actions/configure-pages` (#274), `actions/deploy-pages` (#275), `codecov/codecov-action` (#276)

## Test plan

- [x] Verify CHANGELOG.md formatting renders correctly
- [x] Confirm all PR links resolve to the correct pull requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core library dependencies to specified versions.
  * Updated documentation build tools to latest versions.
  * Updated GitHub Actions workflow versions for deployment and testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/qBraid/qbraid-qir/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->