### PR TITLE
test: skip cudaq→squin tests under typed-pointer pyqir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Types of changes:
 
 ### 🐛  Bug Fixes
 
+- Fixed the cudaq→squin tests (`test_bell_state`, `test_ghz_state`) failing under the typed-pointer pyqir (0.11.x) CI leg. cudaq 0.15+ emits opaque-pointer QIR (QIR 2.0) that only pyqir 0.12+ can parse, so these tests are now gated on `pyqir_uses_opaque_pointers()`. ([#292](https://github.com/qBraid/qbraid-qir/pull/292))
+
 ### ⬇️  Dependency Updates
 
 - Updated `autoqasm` requirement from `>=0.1.0` to `>=0.2.0` ([#278](https://github.com/qBraid/qbraid-qir/pull/278))

--- a/tests/squin_qir/test_cudaq_to_squin.py
+++ b/tests/squin_qir/test_cudaq_to_squin.py
@@ -20,9 +20,12 @@ from qbraid_qir._pyqir_compat import pyqir_uses_opaque_pointers
 
 cudaq = pytest.importorskip("cudaq")
 
-# cudaq 0.15+ emits opaque-pointer QIR (QIR 2.0), which only pyqir 0.12+ can parse.
-# Under the typed-pointer pyqir leg, pyqir.Module.from_ir rejects that text, so these
-# translations can only be exercised against pyqir 0.12+.
+# cudaq 0.15+ emits opaque-pointer QIR (QIR 2.0) with no option to emit typed pointers,
+# and pyqir 0.11.x (LLVM 14) cannot parse opaque pointers -- so pyqir.Module.from_ir
+# rejects cudaq's output on the typed-pointer leg. This is a hard capability requirement,
+# not a workaround: the cudaq->squin path only exists on pyqir 0.12+. The squin loader
+# itself is still exercised on the typed-pointer leg by test_qir_to_squin.py, which loads
+# a committed typed-pointer fixture (parseable by both pyqir versions).
 pytestmark = pytest.mark.skipif(
     not pyqir_uses_opaque_pointers(),
     reason="cudaq emits opaque-pointer QIR that requires pyqir 0.12+ to parse",

--- a/tests/squin_qir/test_cudaq_to_squin.py
+++ b/tests/squin_qir/test_cudaq_to_squin.py
@@ -16,7 +16,17 @@
 
 import pytest
 
+from qbraid_qir._pyqir_compat import pyqir_uses_opaque_pointers
+
 cudaq = pytest.importorskip("cudaq")
+
+# cudaq 0.15+ emits opaque-pointer QIR (QIR 2.0), which only pyqir 0.12+ can parse.
+# Under the typed-pointer pyqir leg, pyqir.Module.from_ir rejects that text, so these
+# translations can only be exercised against pyqir 0.12+.
+pytestmark = pytest.mark.skipif(
+    not pyqir_uses_opaque_pointers(),
+    reason="cudaq emits opaque-pointer QIR that requires pyqir 0.12+ to parse",
+)
 
 # Imports after importorskip so optional dependency is not required at import time.
 from qbraid_qir.squin import load  # pylint: disable=wrong-import-position


### PR DESCRIPTION
## Summary

`tests/squin_qir/test_cudaq_to_squin.py::{test_bell_state,test_ghz_state}` fail on the **pyqir 0.11.x (typed pointers)** CI leg:

```
ValueError: main:6:38: error: expected type
  call void @__quantum__qis__h__body(ptr null)
                                     ^
qbraid_qir/squin/visitor.py:126: ValueError
```

Both tests build a kernel with `cudaq.translate(..., format="qir-base")` and feed the resulting QIR text to `load()`. **cudaq 0.15+ emits opaque-pointer QIR (QIR 2.0)** (`ptr null`), which `pyqir.Module.from_ir` can only parse under pyqir 0.12+. Under the typed-pointer leg it is rejected before any squin conversion runs.

This is dependency drift, not a code regression — it surfaced once cudaq 0.15 shipped, and it affects `main` as well.

## Fix

Gate the module on `pyqir_uses_opaque_pointers()` (the existing `_pyqir_compat` helper, already used to branch the cirq tests on pointer type). The tests run under pyqir 0.12+ and skip under 0.11.x, where cudaq's output is unparseable regardless. No meaningful coverage is lost — the typed-pointer leg physically cannot exercise this path.

## Verification

Confirmed green on both CI legs (typed-pointer skips the two tests; opaque-pointer runs and passes them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)